### PR TITLE
feat: Add Form component and related styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,15 @@
         "@fortawesome/react-fontawesome": "^0.2.1",
         "core-js": "3.31.0",
         "prop-types": "15.8.1",
+        "provinces-ca": "1.0.1",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-paragon-topaz": "1.39.0",
         "react-router": "5.3.3",
         "react-router-dom": "5.3.3",
-        "regenerator-runtime": "0.13.11"
+        "regenerator-runtime": "0.13.11",
+        "states-us": "1.1.1",
+        "world-countries": "5.1.0"
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.1.1",
@@ -14931,6 +14934,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/provinces-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/provinces-ca/-/provinces-ca-1.0.1.tgz",
+      "integrity": "sha512-26+sWKcTGcSVRHLLzaKPXmDpc2zH3pUEjq99YSaO4F7cI/9aqpR6By+HYOVjWr8jdQ7uxuZ/apAQwpmlwDoilw=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -17691,6 +17699,11 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
+    "node_modules/states-us": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/states-us/-/states-us-1.1.1.tgz",
+      "integrity": "sha512-NEtyhDxdHEIpWq2aiJ33V6wCE8Kf5RDPVZ/QhptIrK3LfzwtsAXSVjWTERUe1zS8AmyV8ZnH6MCop4BG/PO9AA=="
+    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -19644,6 +19657,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/world-countries": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/world-countries/-/world-countries-5.1.0.tgz",
+      "integrity": "sha512-CXR6EBvTbArDlDDIWU3gfKb7Qk0ck2WNZ234b/A0vuecPzIfzzxH+O6Ejnvg1sT8XuiZjVlzOH0h08ZtaO7g0w=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,15 @@
     "@fortawesome/react-fontawesome": "^0.2.1",
     "core-js": "3.31.0",
     "prop-types": "15.8.1",
+    "provinces-ca": "1.0.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-paragon-topaz": "1.39.0",
     "react-router": "5.3.3",
     "react-router-dom": "5.3.3",
-    "regenerator-runtime": "0.13.11"
+    "regenerator-runtime": "0.13.11",
+    "states-us": "1.1.1",
+    "world-countries": "5.1.0"
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.1.1",

--- a/src/components/form/__test__/index.test.jsx
+++ b/src/components/form/__test__/index.test.jsx
@@ -1,0 +1,483 @@
+/* eslint-disable react/button-has-type */
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import IdentityForm from 'components/form';
+
+jest.mock('react-paragon-topaz', () => {
+  // eslint-disable-next-line global-require
+  const PropTypes = require('prop-types');
+
+  const Select = ({
+    label, placeholder, options, value, onChange, isDisabled, isClearable, className,
+  }) => {
+    const id = (label || placeholder || 'select')
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9-]/g, '');
+
+    return (
+      <div>
+        <label>{label || placeholder}</label>
+        <select
+          disabled={isDisabled}
+          className={className}
+          value={value?.value || ''}
+          onChange={(e) => {
+            const selectedOption = options?.find(opt => opt.value === e.target.value);
+            onChange?.(selectedOption || null);
+          }}
+          data-testid={`select-input-${id}`}
+        >
+          <option value="">{placeholder || 'Select'}</option>
+          {options?.map((option) => (
+            <option key={option.label} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {isClearable && value && (
+          <button
+            type="button"
+            onClick={() => onChange?.(null)}
+            data-testid={`clear-${id}`}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  Select.propTypes = {
+    label: PropTypes.string,
+    placeholder: PropTypes.string,
+    options: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string,
+    })),
+    value: PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string,
+    }),
+    onChange: PropTypes.func,
+    isDisabled: PropTypes.bool,
+    isClearable: PropTypes.bool,
+    className: PropTypes.string,
+  };
+
+  Select.defaultProps = {
+    label: '',
+    placeholder: '',
+    options: [],
+    value: null,
+    onChange: () => {},
+    isDisabled: false,
+    isClearable: false,
+    className: '',
+  };
+
+  const Button = ({
+    children, variant, type, className, onClick, disabled,
+  }) => (
+    <button
+      type={type || 'button'}
+      className={`btn ${variant} ${className}`}
+      onClick={onClick}
+      disabled={disabled}
+      data-testid={`button-${children?.toLowerCase().replace(/\s+/g, '-')}`}
+    >
+      {children}
+    </button>
+  );
+
+  Button.propTypes = {
+    children: PropTypes.node.isRequired,
+    variant: PropTypes.string,
+    type: PropTypes.string,
+    className: PropTypes.string,
+    onClick: PropTypes.func,
+    disabled: PropTypes.bool,
+  };
+
+  Button.defaultProps = {
+    variant: '',
+    type: 'button',
+    className: '',
+    onClick: () => {},
+    disabled: false,
+  };
+
+  return { Select, Button };
+});
+
+jest.mock('constants', () => ({
+  countries: [
+    {
+      name: 'United States of America',
+      flag: '🇺🇸',
+      dialingCode: '+1',
+      cca3: 'USA',
+      cca2: 'US',
+    },
+    {
+      name: 'Canada',
+      flag: '🇨🇦',
+      dialingCode: '+1',
+      cca3: 'CAN',
+      cca2: 'CA',
+    },
+    {
+      name: 'Mexico',
+      flag: '🇲🇽',
+      dialingCode: '+52',
+      cca3: 'MEX',
+      cca2: 'ME',
+    },
+  ],
+  unitedStates: [
+    { label: 'California', value: 'CA' },
+    { label: 'New York', value: 'NY' },
+    { label: 'Texas', value: 'TX' },
+  ],
+  canadianProvincesAndTerritories: [
+    { label: 'Ontario', value: 'ON' },
+    { label: 'Quebec', value: 'QC' },
+    { label: 'British Columbia', value: 'BC' },
+  ],
+}));
+
+describe('IdentityForm', () => {
+  const mockProps = {
+    onCancel: jest.fn(),
+    onSubmit: jest.fn(),
+    onPrevious: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Initial Rendering', () => {
+    test('renders the component with basic elements', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      expect(screen.getByText('Verify your identity')).toBeInTheDocument();
+      expect(screen.getByText('For security reasons, we need the following information to verify your identity.')).toBeInTheDocument();
+      expect(screen.getByLabelText('First Name *')).toBeInTheDocument();
+      expect(screen.getByLabelText('Last Name *')).toBeInTheDocument();
+      expect(screen.getByLabelText('Email *')).toBeInTheDocument();
+      expect(screen.getByLabelText('Address *')).toBeInTheDocument();
+      expect(screen.getByLabelText('City *')).toBeInTheDocument();
+    });
+
+    test('renders all buttons', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      expect(screen.getByTestId('button-cancel')).toBeInTheDocument();
+      expect(screen.getByTestId('button-previous')).toBeInTheDocument();
+      expect(screen.getByTestId('button-submit')).toBeInTheDocument();
+    });
+
+    test('renders with empty values by default', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      expect(screen.getByLabelText('First Name *')).toHaveValue('');
+      expect(screen.getByLabelText('Last Name *')).toHaveValue('');
+      expect(screen.getByLabelText('Email *')).toHaveValue('');
+    });
+  });
+
+  describe('Text Field Interactions', () => {
+    test('updates first name value when changed', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const firstNameInput = screen.getByLabelText('First Name *');
+      fireEvent.change(firstNameInput, { target: { value: 'John' } });
+
+      expect(firstNameInput).toHaveValue('John');
+    });
+
+    test('updates last name value when changed', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const lastNameInput = screen.getByLabelText('Last Name *');
+      fireEvent.change(lastNameInput, { target: { value: 'Doe' } });
+
+      expect(lastNameInput).toHaveValue('Doe');
+    });
+
+    test('updates email value when changed', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const emailInput = screen.getByLabelText('Email *');
+      fireEvent.change(emailInput, { target: { value: 'john@example.com' } });
+
+      expect(emailInput).toHaveValue('john@example.com');
+    });
+
+    test('updates address value when changed', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const addressInput = screen.getByLabelText('Address *');
+      fireEvent.change(addressInput, { target: { value: '123 Main St' } });
+
+      expect(addressInput).toHaveValue('123 Main St');
+    });
+
+    test('updates apartment value when changed', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const apartmentInput = screen.getByLabelText('Apt #, Suite, Floor');
+      fireEvent.change(apartmentInput, { target: { value: 'Apt 2B' } });
+
+      expect(apartmentInput).toHaveValue('Apt 2B');
+    });
+
+    test('updates city value when changed', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const cityInput = screen.getByLabelText('City *');
+      fireEvent.change(cityInput, { target: { value: 'New York' } });
+
+      expect(cityInput).toHaveValue('New York');
+    });
+
+    test('updates phone value when changed', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const phoneInput = screen.getByLabelText('(555) 555-5555');
+      fireEvent.change(phoneInput, { target: { value: '5551234567' } });
+
+      expect(phoneInput).toHaveValue('5551234567');
+    });
+  });
+
+  describe('Select Fields', () => {
+    test('updates country when selected', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const countrySelect = screen.getByTestId('select-input-country--region');
+      fireEvent.change(countrySelect, { target: { value: 'USA' } });
+
+      expect(countrySelect).toHaveValue('USA');
+    });
+
+    test('updates dialing code when selected', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const dialingCodeSelect = screen.getByTestId('select-input-dialing-code');
+      fireEvent.change(dialingCodeSelect, { target: { value: 'CA' } });
+
+      expect(dialingCodeSelect).toHaveValue('CA');
+    });
+  });
+
+  describe('Conditional Fields for Countries with States', () => {
+    test('displays state and postal code fields when country is United States', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const countrySelect = screen.getByTestId('select-input-country--region');
+      fireEvent.change(countrySelect, { target: { value: 'USA' } });
+
+      expect(screen.getByTestId('select-input-state--province')).toBeInTheDocument();
+      expect(screen.getByLabelText('ZIP / Postal Code *')).toBeInTheDocument();
+    });
+
+    test('displays state and postal code fields when country is Canada', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const countrySelect = screen.getByTestId('select-input-country--region');
+      fireEvent.change(countrySelect, { target: { value: 'CAN' } });
+
+      expect(screen.getByTestId('select-input-state--province')).toBeInTheDocument();
+      expect(screen.getByLabelText('ZIP / Postal Code *')).toBeInTheDocument();
+    });
+
+    test('does not display state and postal code fields for other countries', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const countrySelect = screen.getByTestId('select-input-country--region');
+      fireEvent.change(countrySelect, { target: { value: 'MEX' } });
+
+      expect(screen.queryByTestId('select-input-state--province')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('ZIP / Postal Code *')).not.toBeInTheDocument();
+    });
+
+    test('can select a state when country is United States', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const countrySelect = screen.getByTestId('select-input-country--region');
+      fireEvent.change(countrySelect, { target: { value: 'USA' } });
+
+      const stateSelect = screen.getByTestId('select-input-state--province');
+      fireEvent.change(stateSelect, { target: { value: 'CA' } });
+
+      expect(stateSelect).toHaveValue('CA');
+    });
+
+    test('can select a province when country is Canada', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const countrySelect = screen.getByTestId('select-input-country--region');
+      fireEvent.change(countrySelect, { target: { value: 'CAN' } });
+
+      const stateSelect = screen.getByTestId('select-input-state--province');
+      fireEvent.change(stateSelect, { target: { value: 'ON' } });
+
+      expect(stateSelect).toHaveValue('ON');
+    });
+  });
+
+  describe('Form Submission', () => {
+    test('calls onSubmit with form data when submitted', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const firstNameInput = screen.getByLabelText('First Name *');
+      const lastNameInput = screen.getByLabelText('Last Name *');
+      const emailInput = screen.getByLabelText('Email *');
+
+      fireEvent.change(firstNameInput, { target: { value: 'John' } });
+      fireEvent.change(lastNameInput, { target: { value: 'Doe' } });
+      fireEvent.change(emailInput, { target: { value: 'john@example.com' } });
+
+      const submitButton = screen.getByTestId('button-submit');
+      fireEvent.click(submitButton);
+
+      expect(mockProps.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          firstName: expect.objectContaining({ value: 'John' }),
+          lastName: expect.objectContaining({ value: 'Doe' }),
+          email: expect.objectContaining({ value: 'john@example.com' }),
+        }),
+      );
+    });
+
+    test('prevents default form behavior on submission', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const form = screen.getByRole('form');
+      const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+
+      fireEvent(form, submitEvent);
+
+      expect(submitEvent.defaultPrevented).toBe(true);
+    });
+  });
+
+  describe('Button Events', () => {
+    test('calls onCancel and resets form when Cancel is clicked', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const firstNameInput = screen.getByLabelText('First Name *');
+      fireEvent.change(firstNameInput, { target: { value: 'John' } });
+
+      const cancelButton = screen.getByTestId('button-cancel');
+      fireEvent.click(cancelButton);
+
+      expect(mockProps.onCancel).toHaveBeenCalled();
+      expect(firstNameInput).toHaveValue('');
+    });
+
+    test('calls onPrevious when Previous is clicked', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const previousButton = screen.getByTestId('button-previous');
+      fireEvent.click(previousButton);
+
+      expect(mockProps.onPrevious).toHaveBeenCalled();
+    });
+  });
+
+  describe('Default Props Handling', () => {
+    test('does not fail when onCancel is not provided', () => {
+      const propsWithoutOnCancel = {
+        onSubmit: mockProps.onSubmit,
+        onPrevious: mockProps.onPrevious,
+      };
+
+      render(<IdentityForm {...propsWithoutOnCancel} />);
+
+      const cancelButton = screen.getByTestId('button-cancel');
+      expect(() => fireEvent.click(cancelButton)).not.toThrow();
+    });
+
+    test('does not fail when onPrevious is not provided', () => {
+      const propsWithoutOnPrevious = {
+        onSubmit: mockProps.onSubmit,
+        onCancel: mockProps.onCancel,
+      };
+
+      render(<IdentityForm {...propsWithoutOnPrevious} />);
+
+      const previousButton = screen.getByTestId('button-previous');
+      expect(() => fireEvent.click(previousButton)).not.toThrow();
+    });
+  });
+
+  describe('Loading State', () => {
+    test('displays loading text on submit button when loading', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      expect(screen.getByTestId('button-submit')).toHaveTextContent('Submit');
+    });
+  });
+
+  describe('Form Validation and Accessibility', () => {
+    test('has correct labels for required fields', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      expect(screen.getByLabelText('First Name *')).toBeRequired();
+      expect(screen.getByLabelText('Last Name *')).toBeRequired();
+      expect(screen.getByLabelText('Email *')).toBeRequired();
+      expect(screen.getByLabelText('Address *')).toBeRequired();
+      expect(screen.getByLabelText('City *')).toBeRequired();
+    });
+
+    test('email field has the correct type', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      expect(screen.getByLabelText('Email *')).toHaveAttribute('type', 'email');
+    });
+
+    test('phone field has the correct attributes', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const phoneInput = screen.getByLabelText('(555) 555-5555');
+      expect(phoneInput).toHaveAttribute('type', 'tel');
+      expect(phoneInput).toHaveAttribute('inputMode', 'numeric');
+    });
+  });
+
+  describe('Phone Input Component', () => {
+    test('updates phone and dialing code independently', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const dialingCodeSelect = screen.getByTestId('select-input-dialing-code');
+      const phoneInput = screen.getByLabelText('(555) 555-5555');
+
+      fireEvent.change(dialingCodeSelect, { target: { value: 'CA' } });
+      fireEvent.change(phoneInput, { target: { value: '4161234567' } });
+
+      expect(dialingCodeSelect).toHaveValue('CA');
+      expect(phoneInput).toHaveValue('4161234567');
+    });
+  });
+
+  describe('State Management', () => {
+    test('clears error when field value changes', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const firstNameInput = screen.getByLabelText('First Name *');
+      fireEvent.change(firstNameInput, { target: { value: 'John' } });
+
+      expect(firstNameInput).toHaveValue('John');
+    });
+  });
+});

--- a/src/components/form/components/index.jsx
+++ b/src/components/form/components/index.jsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form, Col } from '@edx/paragon';
+import { Select } from 'react-paragon-topaz';
+
+import { countries } from 'constants';
+
+const baseSelectStyles = {
+  minHeight: 50,
+  maxHeight: 50,
+};
+
+const parsedPhoneCountries = countries?.map(country => ({
+  label: `${JSON.parse(`"${country.flag}"`)} ${country.dialingCode}`,
+  value: country.cca2,
+}));
+
+export const Input = ({
+  id,
+  label,
+  type = 'text',
+  required = false,
+  value,
+  error,
+  isDisabled,
+  isLoading,
+  onChange,
+  placeholder,
+  inputMode,
+  className = '',
+  xs = 12,
+  md = 6,
+}) => (
+  <Form.Group as={Col} xs={xs} md={md} controlId={id} isInvalid={!!error}>
+    <Form.Control
+      type={type}
+      floatingLabel={label}
+      placeholder={placeholder}
+      required={required}
+      disabled={isDisabled || isLoading}
+      className={`${isDisabled || isLoading ? 'form-input-disabled' : 'form-input'} ${className}`}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      inputMode={inputMode}
+    />
+    {error && (
+      <Form.Control.Feedback type="invalid">
+        {error}
+      </Form.Control.Feedback>
+    )}
+  </Form.Group>
+);
+
+export const SelectInput = ({
+  id,
+  label,
+  placeholder,
+  options,
+  value,
+  error,
+  isDisabled,
+  isLoading,
+  onChange,
+  isClearable = true,
+  styles = {},
+  className = '',
+  xs = 12,
+  md = 6,
+}) => (
+  <Form.Group as={Col} xs={xs} md={md} controlId={id} isInvalid={!!error}>
+    <Select
+      label={label}
+      placeholder={placeholder}
+      className={`form-select ${className}`}
+      options={options}
+      value={options?.find((option) => option.value === value)}
+      onChange={(opt) => onChange(opt?.value || '')}
+      isDisabled={isDisabled || isLoading}
+      isClearable={isClearable}
+      styles={{
+        control: (base) => ({
+          ...base,
+          ...baseSelectStyles,
+          ...styles.control,
+        }),
+        ...styles,
+      }}
+    />
+    {error && (
+      <Form.Control.Feedback type="invalid">
+        {error}
+      </Form.Control.Feedback>
+    )}
+  </Form.Group>
+);
+
+export const PhoneInput = ({
+  dialingCodeValue,
+  dialingCodeDisabled,
+  phoneValue,
+  phoneError,
+  dialingCodeError,
+  phoneDisabled,
+  isLoading,
+  onDialingCodeChange,
+  onPhoneChange,
+}) => (
+  <Form.Group as={Col} xs={12} md={6} controlId="phone" isInvalid={!!phoneError}>
+    <Form.Row>
+      <div className="form-phone">
+        <Col xs={5} md={3} className="px-0 pl-1">
+          <Select
+            label="Dialing code"
+            className="form-input"
+            placeholder="Select"
+            options={parsedPhoneCountries}
+            value={parsedPhoneCountries?.find((c) => c.value === dialingCodeValue)}
+            onChange={(opt) => onDialingCodeChange(opt?.value || '')}
+            isClearable
+            isDisabled={dialingCodeDisabled || isLoading}
+            styles={{
+              control: (base) => ({
+                ...base,
+                ...baseSelectStyles,
+                borderRight: 'none',
+                borderTopRightRadius: 0,
+                borderBottomRightRadius: 0,
+              }),
+            }}
+          />
+        </Col>
+        <Col xs={7} md={9} className="px-0">
+          <Form.Control
+            type="tel"
+            inputMode="numeric"
+            floatingLabel="(555) 555-5555"
+            placeholder="(555) 555-5555"
+            value={phoneValue}
+            disabled={phoneDisabled || isLoading}
+            className={`pr-1 form-phone-input ${phoneDisabled || isLoading ? 'form-input-disabled' : 'form-input'}`}
+            onChange={(e) => onPhoneChange(e.target.value)}
+          />
+          {(phoneError || dialingCodeError) && (
+            <Form.Control.Feedback type="invalid">
+              {phoneError || dialingCodeError}
+            </Form.Control.Feedback>
+          )}
+        </Col>
+      </div>
+    </Form.Row>
+  </Form.Group>
+);
+
+Input.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  type: PropTypes.string,
+  required: PropTypes.bool,
+  value: PropTypes.string.isRequired,
+  error: PropTypes.string,
+  isDisabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  inputMode: PropTypes.string,
+  className: PropTypes.string,
+  xs: PropTypes.number,
+  md: PropTypes.number,
+};
+
+Input.defaultProps = {
+  type: 'text',
+  required: false,
+  error: null,
+  isDisabled: false,
+  isLoading: false,
+  placeholder: '',
+  inputMode: 'text',
+  className: '',
+  xs: undefined,
+  md: undefined,
+};
+
+SelectInput.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  options: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        country: PropTypes.string.isRequired,
+        code: PropTypes.string.isRequired,
+      }),
+    ]),
+  ).isRequired,
+  value: PropTypes.string.isRequired,
+  error: PropTypes.string,
+  isDisabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+  isClearable: PropTypes.bool,
+  styles: PropTypes.objectOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.object,
+    PropTypes.func,
+  ])),
+  className: PropTypes.string,
+  xs: PropTypes.number,
+  md: PropTypes.number,
+};
+
+SelectInput.defaultProps = {
+  placeholder: '',
+  error: null,
+  isDisabled: false,
+  isLoading: false,
+  isClearable: false,
+  styles: {},
+  className: '',
+  xs: undefined,
+  md: undefined,
+};
+
+PhoneInput.propTypes = {
+  dialingCodeValue: PropTypes.string.isRequired,
+  dialingCodeDisabled: PropTypes.bool,
+  phoneValue: PropTypes.string.isRequired,
+  phoneError: PropTypes.string,
+  dialingCodeError: PropTypes.string,
+  phoneDisabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  onDialingCodeChange: PropTypes.func.isRequired,
+  onPhoneChange: PropTypes.func.isRequired,
+};
+
+PhoneInput.defaultProps = {
+  dialingCodeDisabled: false,
+  phoneError: null,
+  dialingCodeError: null,
+  phoneDisabled: false,
+  isLoading: false,
+};

--- a/src/components/form/index.jsx
+++ b/src/components/form/index.jsx
@@ -1,0 +1,294 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Form } from '@edx/paragon';
+import { Button } from 'react-paragon-topaz';
+
+import { Input, PhoneInput, SelectInput } from 'components/form/components';
+import { countries, unitedStates, canadianProvincesAndTerritories } from 'constants';
+import './index.scss';
+
+const UNITED_STATES = 'USA';
+const CANADA = 'CAN';
+
+const states = {
+  [UNITED_STATES]: unitedStates,
+  [CANADA]: canadianProvincesAndTerritories,
+};
+
+const countryDivitionPlaceholder = {
+  [UNITED_STATES]: 'State *',
+  [CANADA]: 'Province / Territory *',
+};
+
+const getStateOptions = (country) => states[country] || [];
+
+const parsedCountries = countries?.map(country => ({
+  label: `${JSON.parse(`"${country.flag}"`)} ${country.name}`,
+  value: country.cca3,
+}));
+
+const countriesWithStates = [UNITED_STATES, CANADA];
+
+const FormHeader = () => (
+  <Form.Row className="flex-column mb-4 pl-1">
+    <h3 className="form-title">Verify your identity</h3>
+    <p className="form-subtitle">For security reasons, we need the following information to verify your identity.</p>
+  </Form.Row>
+);
+
+const FormActions = ({ onCancel, onPrevious, isLoading }) => (
+  <div className="d-flex justify-content-between border-top px-3 px-md-4 p-md-4 py-4">
+    <div className="d-flex justify-content-start gap-2">
+      <Button
+        variant="tertiary"
+        type="button"
+        className="p-2 px-md-4 mr-1 mr-md-0"
+        onClick={onCancel}
+        disabled={isLoading}
+      >
+        Cancel
+      </Button>
+    </div>
+    <div className="d-flex justify-content-end gap-2">
+      <Button
+        variant="primary"
+        text
+        type="button"
+        className="mr-2 mr-md-3 p-2 px-md-4"
+        onClick={onPrevious}
+        disabled={isLoading}
+      >
+        Previous
+      </Button>
+      <Button
+        className="p-2 px-md-4 py-3"
+        variant="outline-primary"
+        type="submit"
+        disabled={isLoading}
+      >
+        {isLoading ? 'Submitting...' : 'Submit'}
+      </Button>
+    </div>
+  </div>
+);
+
+const initialFormState = {
+  firstName: { isDisabled: false, value: '', error: null },
+  lastName: { isDisabled: false, value: '', error: null },
+  email: { isDisabled: false, value: '', error: null },
+  dialingCode: { isDisabled: false, value: UNITED_STATES, error: null },
+  phone: { isDisabled: false, value: '', error: null },
+  address: { isDisabled: false, value: '', error: null },
+  apartment: { isDisabled: false, value: '', error: null },
+  city: { isDisabled: false, value: '', error: null },
+  state: { isDisabled: false, value: '', error: null },
+  postalCode: { isDisabled: false, value: '', error: null },
+  country: { isDisabled: false, value: '', error: null },
+};
+
+/**
+ * Identity verification form component with local state management
+ * @param {Object} props - Component props
+ * @param {Function} props.onSubmit - Callback function called when form is submitted with form data
+ * @param {Function} props.onCancel - Optional callback function called when cancel button is clicked
+ * @param {Function} props.onPrevious - Optional callback function called when previous button is clicked
+ * @returns {JSX.Element} The identity form component
+ */
+const IdentityForm = ({
+  onSubmit,
+  onCancel = () => {},
+  onPrevious = () => {},
+}) => {
+  const [isLoading] = useState(false);
+  const [formData, setFormData] = useState(initialFormState);
+
+  const handleInputChange = (name, value) => {
+    setFormData(prev => ({
+      ...prev,
+      [name]: {
+        ...prev[name],
+        value,
+        error: null,
+      },
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(formData);
+  };
+
+  const handleCancel = () => {
+    setFormData(initialFormState);
+    onCancel();
+  };
+
+  const showStateAndPostalCodeField = countriesWithStates.includes(formData.country.value);
+
+  return (
+    <Form onSubmit={handleSubmit} className="p-0 pt-3 form-wrapper" role="form">
+      <div className="p-4">
+        <FormHeader />
+
+        <Form.Row className="d-flex flex-wrap">
+          <Input
+            id="firstName"
+            label="First Name *"
+            required
+            value={formData.firstName.value}
+            error={formData.firstName.error}
+            isDisabled={formData.firstName.isDisabled}
+            isLoading={isLoading}
+            onChange={(value) => handleInputChange('firstName', value)}
+          />
+
+          <Input
+            id="lastName"
+            label="Last Name *"
+            required
+            value={formData.lastName.value}
+            error={formData.lastName.error}
+            isDisabled={formData.lastName.isDisabled}
+            isLoading={isLoading}
+            onChange={(value) => handleInputChange('lastName', value)}
+          />
+        </Form.Row>
+
+        <Form.Row>
+          <Input
+            id="email"
+            label="Email *"
+            type="email"
+            required
+            value={formData.email.value}
+            error={formData.email.error}
+            isDisabled={formData.email.isDisabled}
+            isLoading={isLoading}
+            onChange={(value) => handleInputChange('email', value)}
+          />
+
+          <PhoneInput
+            dialingCodeValue={formData.dialingCode.value}
+            dialingCodeError={formData.dialingCode.error}
+            dialingCodeDisabled={formData.dialingCode.isDisabled}
+            phoneValue={formData.phone.value}
+            phoneError={formData.phone.error}
+            phoneDisabled={formData.phone.isDisabled}
+            isLoading={isLoading}
+            onDialingCodeChange={(value) => handleInputChange('dialingCode', value)}
+            onPhoneChange={(value) => handleInputChange('phone', value)}
+          />
+        </Form.Row>
+
+        <Form.Row>
+          <Input
+            id="address"
+            label="Address *"
+            required
+            value={formData.address.value}
+            error={formData.address.error}
+            isDisabled={formData.address.isDisabled}
+            isLoading={isLoading}
+            onChange={(value) => handleInputChange('address', value)}
+          />
+
+          <Input
+            id="apartment"
+            label="Apt #, Suite, Floor"
+            value={formData.apartment.value}
+            error={formData.apartment.error}
+            isDisabled={formData.apartment.isDisabled}
+            isLoading={isLoading}
+            onChange={(value) => handleInputChange('apartment', value)}
+          />
+        </Form.Row>
+
+        <Form.Row>
+          <Input
+            id="city"
+            label="City *"
+            required
+            value={formData.city.value}
+            error={formData.city.error}
+            isDisabled={formData.city.isDisabled}
+            isLoading={isLoading}
+            onChange={(value) => handleInputChange('city', value)}
+          />
+
+          {showStateAndPostalCodeField && (
+            <SelectInput
+              id="state"
+              label="State / Province"
+              placeholder={countryDivitionPlaceholder[formData.country.value] || 'State / Province *'}
+              options={getStateOptions(formData.country.value)}
+              value={formData.state.value}
+              error={formData.state.error}
+              isDisabled={formData.state.isDisabled}
+              isLoading={isLoading}
+              onChange={(value) => handleInputChange('state', value)}
+            />
+          )}
+        </Form.Row>
+
+        <Form.Row>
+          {showStateAndPostalCodeField && (
+            <Input
+              id="postalCode"
+              label="ZIP / Postal Code *"
+              required
+              value={formData.postalCode.value}
+              error={formData.postalCode.error}
+              isDisabled={formData.postalCode.isDisabled}
+              isLoading={isLoading}
+              onChange={(value) => handleInputChange('postalCode', value)}
+            />
+          )}
+
+          <SelectInput
+            id="country"
+            label="Country / Region"
+            placeholder="Country / Region *"
+            className="form-input"
+            options={parsedCountries}
+            value={formData.country.value}
+            error={formData.country.error}
+            isDisabled={formData.country.isDisabled}
+            isLoading={isLoading}
+            onChange={(value) => handleInputChange('country', value)}
+          />
+        </Form.Row>
+      </div>
+
+      <FormActions
+        onCancel={handleCancel}
+        onPrevious={onPrevious}
+        isLoading={isLoading}
+      />
+    </Form>
+  );
+};
+
+FormActions.propTypes = {
+  onCancel: PropTypes.func,
+  onPrevious: PropTypes.func,
+  isLoading: PropTypes.bool,
+};
+
+FormActions.defaultProps = {
+  onCancel: null,
+  onPrevious: null,
+  isLoading: false,
+};
+
+IdentityForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  onCancel: PropTypes.func,
+  onPrevious: PropTypes.func,
+};
+
+IdentityForm.defaultProps = {
+  onCancel: () => {},
+  onPrevious: () => {},
+};
+
+export default IdentityForm;

--- a/src/components/form/index.scss
+++ b/src/components/form/index.scss
@@ -1,0 +1,65 @@
+@import 'react-paragon-topaz/src/variables.scss';
+
+.form-wrapper {
+  background-color: #fff;
+  border-radius: 8px;
+  border: 1px solid #ced4da;
+}
+
+.form-title {
+  color: $primary-dark;
+
+  @media screen and (max-width: 576px) {
+    font-size: 24px;
+  }
+}
+
+.form-subtitle {
+  color: #002646;
+  font-size: 16px;
+}
+
+.form-select {
+  width: 99%;
+  max-height: 50px;
+
+  @media screen and (max-width: 576px) {
+    width: 100%;
+  }
+}
+
+.form-phone {
+  display: flex;
+  width: 100%;
+}
+
+.form-phone-input input.form-control {
+  border-left: none;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.form-input input.form-control {
+  border: 1px solid #ced4da;
+}
+
+.form-input input.form-control.is-invalid {
+  border-color: #da3100;
+}
+
+.form-input input.form-control:hover {
+  outline: 2px solid #ced4da;
+}
+
+.form-input-disabled input.form-control,
+.form-input-disabled input.form-control:hover {
+  padding-left: 0;
+  outline: none;
+  background-color: #fff;
+  border: none;
+}
+
+.form-input-disabled .pgn__form-control-floating-label-text {
+  position: relative;
+  left: -15px;
+}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,27 @@
+import provinces from 'provinces-ca';
+import states from 'states-us';
+import countriesData from 'world-countries';
+
+export const canadianProvincesAndTerritories = provinces.map(
+  ({ name, abbreviation }) => ({
+    label: name,
+    value: abbreviation,
+  }),
+);
+
+export const unitedStates = states.map(({ name, abbreviation }) => ({
+  label: name,
+  value: abbreviation,
+}));
+
+export const countries = countriesData
+  .map(({
+    name: { official }, flag, idd: { root, suffixes }, cca3, cca2,
+  }) => ({
+    name: official,
+    flag,
+    dialingCode: suffixes && suffixes.length === 1 ? root + suffixes[0] : root,
+    cca3,
+    cca2,
+  }))
+  .filter(({ dialingCode }) => dialingCode);

--- a/src/features/SchedulePage/__test__/index.test.jsx
+++ b/src/features/SchedulePage/__test__/index.test.jsx
@@ -16,11 +16,22 @@ jest.mock('react-paragon-topaz', () => ({
   Header: ({ src, logoUrl }) => (
     <div data-testid="header" data-src={src} data-url={logoUrl}>Mock Header</div>
   ),
+  Button: () => (
+    <div data-testid="button">Button</div>
+  ),
+  Select: () => (
+    <div data-testid="select">Select</div>
+  ),
 }));
 
-jest.mock('@edx/paragon', () => ({
-  Container: ({ children }) => <div data-testid="container">{children}</div>,
-}));
+jest.mock('@edx/paragon', () => {
+  const actualParagon = jest.requireActual('@edx/paragon');
+
+  return {
+    ...actualParagon,
+    Container: ({ children }) => <div data-testid="container">{children}</div>,
+  };
+});
 
 jest.mock('components/TermsConditions', () => function ({ onAccept, onCancel }) {
   return (
@@ -59,8 +70,9 @@ describe('SchedulePage', () => {
 
   test('renders form component after accepting terms', () => {
     render(<SchedulePage />);
+
     fireEvent.click(screen.getByText('Accept'));
     expect(screen.queryByTestId('terms')).not.toBeInTheDocument();
-    expect(screen.getByText('Form Component')).toBeInTheDocument();
+    expect(screen.getByText('Verify your identity')).toBeInTheDocument();
   });
 });

--- a/src/features/SchedulePage/index.jsx
+++ b/src/features/SchedulePage/index.jsx
@@ -4,6 +4,7 @@ import { Header } from 'react-paragon-topaz';
 import { Container } from '@edx/paragon';
 
 import TermsConditions from 'components/TermsConditions';
+import IdentityForm from 'components/form';
 
 const SchedulePage = () => {
   const [acceptedTerms, setAcceptedTerms] = useState(false);
@@ -18,7 +19,7 @@ const SchedulePage = () => {
         src={getConfig().LOGO_URL}
         logoUrl={getConfig().LMS_BASE_URL}
       />
-      <div className="pageWrapper p-4">
+      <div className="pageWrapper p-3">
         <Container size="xl" className="bg-white rounded p-0">
           {!acceptedTerms && (
           <TermsConditions
@@ -26,7 +27,7 @@ const SchedulePage = () => {
             onCancel={handleCancelTerms}
           />
           )}
-          {acceptedTerms && <div>Form Component</div>}
+          {acceptedTerms && <IdentityForm onSubmit={alert} />}
         </Container>
       </div>
     </>

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,5 @@
 @import "react-paragon-topaz/src/variables.scss";
+
 @import "@edx/brand/paragon/fonts.scss";
 @import "@edx/brand/paragon/variables.scss";
 @import "@edx/paragon/scss/core/core.scss";

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -7,6 +7,7 @@ module.exports = createConfig('webpack-dev', {
       components: path.resolve(__dirname, 'src/components'),
       features: path.resolve(__dirname, 'src/features'),
       assets: path.resolve(__dirname, 'src/assets'),
+      constants: path.resolve(__dirname, 'src/constants'),
     },
   },
   devServer: {

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -7,6 +7,7 @@ module.exports = createConfig('webpack-dev', {
       components: path.resolve(__dirname, 'src/components'),
       features: path.resolve(__dirname, 'src/features'),
       assets: path.resolve(__dirname, 'src/assets'),
+      constants: path.resolve(__dirname, 'src/constants'),
     },
   },
 });


### PR DESCRIPTION
# Description
In this PR is added the form to verify the user information.

## Ticket
https://pearson.atlassian.net/browse/PADV-2170

## Change log
- Created a new IdentityForm component and integrated it into the main App component.
- Added SCSS styles for the form in src/components/form/index.scss.
- Introduced constants for Canadian provinces, US states, and countries in src/constants/index.js.
- Updated index.scss to include new form styles and variables.
- Modified webpack configuration to include a new alias for constants.

## Visual results
![localhost_2005_exam (1)](https://github.com/user-attachments/assets/d045bb2d-6aad-4865-a6d0-4957483cb834)
![localhost_2005_exam](https://github.com/user-attachments/assets/af577125-2025-49a4-9160-1785a0b45750)


## How to test
- Start the mfe
- Go to `/exam` path 
- You should be able to see the form.