### PR TITLE
feat: empty exam view

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -1,3 +1,15 @@
+@import 'react-paragon-topaz/src/variables.scss';
+
 $blue-90 : #002646;
 
 $bg-main-color: #f3f3f3;
+$bg-dashboard-color: #f8f9fa;
+
+$gray-border: $gray-40;
+
+$card-bg: $white;
+$card-shadow: rgba(0, 0, 0, 0.1);
+
+$placeholder-text: $gray-70;
+$placeholder-border: $gray-30;
+$placeholder-title: $gray-80;

--- a/src/features/DashboardPage/components/NoContentPlaceholder/index.jsx
+++ b/src/features/DashboardPage/components/NoContentPlaceholder/index.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const NoContentPlaceholder = ({ title, description }) => (
+  <div className="no-content-placeholder-container">
+    <h3>{title}</h3>
+    <p>{description}</p>
+  </div>
+);
+
+NoContentPlaceholder.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+};
+
+NoContentPlaceholder.defaultProps = {
+  title: 'No exams found',
+  description: 'It looks like you don\'t have exams or vouchers.',
+};
+
+export default NoContentPlaceholder;

--- a/src/features/DashboardPage/components/__test__/index.test.jsx
+++ b/src/features/DashboardPage/components/__test__/index.test.jsx
@@ -1,0 +1,22 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import NoContentPlaceholder from 'features/DashboardPage/components/NoContentPlaceholder';
+
+describe('NoContentPlaceholder', () => {
+  test('Should render default title and description when no props are provided', () => {
+    render(<NoContentPlaceholder />);
+    expect(screen.getByText('No exams found')).toBeInTheDocument();
+    expect(screen.getByText("It looks like you don't have exams or vouchers.")).toBeInTheDocument();
+  });
+
+  test('Should render custom title and description when props are provided', () => {
+    render(
+      <NoContentPlaceholder
+        title="Custom Title"
+        description="Custom Description"
+      />,
+    );
+    expect(screen.getByText('Custom Title')).toBeInTheDocument();
+    expect(screen.getByText('Custom Description')).toBeInTheDocument();
+  });
+});

--- a/src/features/DashboardPage/index.jsx
+++ b/src/features/DashboardPage/index.jsx
@@ -1,15 +1,29 @@
 import React from 'react';
-
+import { Tabs, Tab } from '@edx/paragon';
 import Header from '@edx/frontend-component-header';
 
-const DashboardPage = () => (
-  <>
-    <Header />
-    <div>
-      <h1>Dashboard Page</h1>
-    </div>
-  </>
+import NoContentPlaceholder from 'features/DashboardPage/components/NoContentPlaceholder';
+import './index.scss';
 
+const DashboardPage = () => (
+  <div className="dashboard-container">
+    <Header />
+    <div className="tabs-container">
+      <Tabs
+        defaultActiveKey="exams"
+        id="tabs"
+        variant="button-group"
+        className="tabs-wrapper"
+      >
+        <Tab eventKey="exams" title="Exams" className="tab-content-wrapper">
+          <NoContentPlaceholder />
+        </Tab>
+        <Tab eventKey="past-exams" title="Past Exams" className="tab-content-wrapper">
+          <NoContentPlaceholder title="No past exams found" description="It looks like you do not have past exams." />
+        </Tab>
+      </Tabs>
+    </div>
+  </div>
 );
 
 export default DashboardPage;

--- a/src/features/DashboardPage/index.scss
+++ b/src/features/DashboardPage/index.scss
@@ -1,0 +1,91 @@
+@import 'react-paragon-topaz/src/variables.scss';
+@import 'assets/variables.scss';
+
+.dashboard-container {
+  background-color: $bg-dashboard-color;
+  min-height: 100vh;
+}
+
+.tabs-container {
+  background-color: $card-bg;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px $card-shadow;
+  margin: 0 2rem;
+  margin-top: 2rem;
+  border: 1px solid $gray-border;
+
+  @media screen and (max-width: 576px) {
+    margin: 0.5rem;
+    margin-top: 1rem;
+  }
+}
+
+.tabs-wrapper {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  padding: 1.5em 1.5em 1.2em 1.5em;
+  background-color: $gray-20;
+}
+
+nav[role='tablist'] {
+  padding-left: 1em;
+}
+
+a.nav-link:not(.active)[role='tab'][data-rb-event-key] {
+  border-color: $gray-border;
+}
+
+a.nav-link.active[role='tab'][data-rb-event-key],
+#pgn__tab-toggle,
+#tabs-tab-null {
+  border-color: $blue-80;
+  background-color: $blue-80;
+  color: $white;
+}
+
+#tabs-tab-past-exams,
+#tabs-tab-exams {
+  padding: 0.5rem 2rem;
+}
+
+.tab-content-wrapper {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+  border-radius: 4px;
+}
+
+.no-content-placeholder-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  color: $placeholder-text;
+  margin: 1em 3em;
+  margin-top: 2.5em;
+  border: 1px solid $placeholder-border;
+  border-radius: 8px;
+
+  @media screen and (max-width: 576px) {
+    margin: 1em;
+    padding: 24px;
+  }
+}
+
+.no-content-placeholder-container h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: $placeholder-title;
+}
+
+.no-content-placeholder-container p {
+  font-size: 1rem;
+  line-height: 1.5;
+
+  @media screen and (max-width: 576px) {
+    text-align: center;
+  }
+}


### PR DESCRIPTION
# Description
In this PR is added the empty state for exams.

## Ticket
https://pearson.atlassian.net/browse/PADV-2215

## Change log
- Created a new component and integrated it into the main App component.
- Added SCSS styles for the component.

## Visual results
![localhost_2004_dashboard (1)](https://github.com/user-attachments/assets/4402980f-ebec-42b6-84d8-53227b074299)
![localhost_2004_dashboard](https://github.com/user-attachments/assets/dff08e9d-abd4-4ded-98ba-8d8a1e44b98c)


## How to test
- Start the mfe
- Go to `/dashboard` path 
- You should be able to see the component.