### PR TITLE
PADV-2429 feat: add exam service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/react-fontawesome": "^0.2.1",
         "core-js": "3.31.0",
+        "date-fns": "3.6.0",
         "prop-types": "15.8.1",
         "provinces-ca": "1.0.1",
         "react": "16.14.0",
@@ -148,14 +149,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@babel/types": "^7.27.3",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -237,6 +238,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
@@ -392,11 +401,11 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.28.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1720,26 +1729,26 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
-        "@babel/parser": "^7.27.4",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.0",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/types": "^7.28.0",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
-      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -1961,6 +1970,56 @@
         "react": "^16.9.0 || ^17.0.0"
       }
     },
+    "node_modules/@edx/frontend-build/node_modules/babel-jest": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+      "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
+      "dependencies": {
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/babel__core": "^7.1.7",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-preset-jest": "^26.6.2",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@edx/frontend-build/node_modules/babel-jest/node_modules/babel-preset-jest": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+      "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^26.6.2",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@edx/frontend-build/node_modules/babel-plugin-jest-hoist": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+      "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
     "node_modules/@edx/frontend-build/node_modules/postcss": {
       "version": "8.4.30",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
@@ -1986,6 +2045,14 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/@edx/frontend-build/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@edx/frontend-component-footer": {
@@ -3578,30 +3645,18 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3621,9 +3676,9 @@
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -5440,35 +5495,6 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
       "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg=="
     },
-    "node_modules/babel-jest": {
-      "version": "26.6.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
-      "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
-      "dependencies": {
-        "@jest/transform": "^26.6.2",
-        "@jest/types": "^26.6.2",
-        "@types/babel__core": "^7.1.7",
-        "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^26.6.2",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/babel-loader": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.1.3.tgz",
@@ -5547,20 +5573,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-jest-hoist": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
-      "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
-      "dependencies": {
-        "@babel/template": "^7.3.3",
-        "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.0.0",
-        "@types/babel__traverse": "^7.0.6"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -5744,21 +5756,6 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/babel-preset-jest": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
-      "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
-      "dependencies": {
-        "babel-plugin-jest-hoist": "^26.6.2",
-        "babel-preset-current-node-syntax": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -11465,6 +11462,56 @@
         }
       }
     },
+    "node_modules/jest-config/node_modules/babel-jest": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+      "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
+      "dependencies": {
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/babel__core": "^7.1.7",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-preset-jest": "^26.6.2",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/babel-plugin-jest-hoist": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+      "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/jest-config/node_modules/babel-preset-jest": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+      "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^26.6.2",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/jest-config/node_modules/jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
@@ -11485,6 +11532,14 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/jest-config/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-diff": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.1",
     "core-js": "3.31.0",
+    "date-fns": "3.6.0",
     "prop-types": "15.8.1",
     "provinces-ca": "1.0.1",
     "react": "16.14.0",

--- a/src/components/ExamCard/index.jsx
+++ b/src/components/ExamCard/index.jsx
@@ -13,6 +13,7 @@ import {
 import { MoreVert } from '@edx/paragon/icons';
 
 import './index.scss';
+import { examStatus } from 'features/utils/constants';
 
 const statusTextMap = {
   complete: 'Complete',
@@ -32,7 +33,7 @@ const statusStyleMap = {
   unscheduled: 'badge-unscheduled',
 };
 
-const allowedStatuses = ['complete', 'scheduled'];
+const allowedStatuses = [examStatus.COMPLETE, examStatus.SCHEDULED];
 
 const ExamCard = ({
   title,
@@ -42,6 +43,7 @@ const ExamCard = ({
   additionalExamDetails,
   onScheduleExam,
   dropdownItems,
+  hideFooter,
 }) => {
   const [isOpen, open, close] = useToggle(false);
   const statusClass = statusClassMap[status] || '';
@@ -91,18 +93,20 @@ const ExamCard = ({
             ))}
           </ul>
         </Card.Section>
-        <Card.Footer className="px-4 pb-4 d-flex flex-column">
-          <div className="custom-card-separator" />
-          {status === 'unscheduled' ? (
-            <Button onClick={onScheduleExam} className="m-0" id="custom-card-button-schedule">
-              Schedule Exam
-            </Button>
-          ) : (
-            <Button onClick={open} className="m-0" id="custom-card-button-voucher-details">
-              Voucher Details
-            </Button>
-          )}
-        </Card.Footer>
+        {!hideFooter && (
+          <Card.Footer className="px-4 pb-4 d-flex flex-column">
+            <div className="custom-card-separator" />
+            {status === examStatus.UNSCHEDULED ? (
+              <Button onClick={onScheduleExam} className="m-0" id="custom-card-button-schedule">
+                Schedule Exam
+              </Button>
+            ) : (
+              <Button onClick={open} className="m-0" id="custom-card-button-voucher-details">
+                Voucher Details
+              </Button>
+            )}
+          </Card.Footer>
+        )}
       </Card>
       <ModalDialog
         title="Voucher Details"
@@ -132,7 +136,7 @@ const ExamCard = ({
 
 ExamCard.propTypes = {
   title: PropTypes.string.isRequired,
-  status: PropTypes.oneOf(['complete', 'scheduled', 'unscheduled']).isRequired,
+  status: PropTypes.oneOf([examStatus.COMPLETE, examStatus.SCHEDULED, examStatus.UNSCHEDULED]).isRequired,
   image: PropTypes.string,
   examDetails: PropTypes.arrayOf(
     PropTypes.shape({
@@ -154,6 +158,7 @@ ExamCard.propTypes = {
       onClick: PropTypes.func.isRequired,
     }),
   ),
+  hideFooter: PropTypes.bool,
 };
 
 ExamCard.defaultProps = {
@@ -161,6 +166,7 @@ ExamCard.defaultProps = {
   dropdownItems: null,
   onScheduleExam: () => {},
   additionalExamDetails: [],
+  hideFooter: false,
 };
 
 export default ExamCard;

--- a/src/components/form/components/index.jsx
+++ b/src/components/form/components/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Col } from '@edx/paragon';
 import { Select } from 'react-paragon-topaz';
 
-import { countries } from 'constants';
+import { countries } from 'features/utils/constants';
 
 const baseSelectStyles = {
   minHeight: 50,

--- a/src/components/form/index.jsx
+++ b/src/components/form/index.jsx
@@ -5,7 +5,7 @@ import { Button } from 'react-paragon-topaz';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { Input, PhoneInput, SelectInput } from 'components/form/components';
-import { countries, unitedStates, canadianProvincesAndTerritories } from 'constants';
+import { countries, unitedStates, canadianProvincesAndTerritories } from 'features/utils/constants';
 import { getUserData } from 'features/data/api';
 import './index.scss';
 

--- a/src/features/DashboardPage/__test__/index.test.jsx
+++ b/src/features/DashboardPage/__test__/index.test.jsx
@@ -1,0 +1,123 @@
+/* eslint-disable func-names, react/prop-types */
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { render } from 'test-utils';
+import DashboardPage from 'features/DashboardPage';
+import * as api from 'features/data/api';
+
+jest.mock('@edx/frontend-component-header', () => function () {
+  return <div data-testid="header" />;
+});
+jest.mock('components/ExamCard', () => function ({ title, status, examDetails }) {
+  return (
+    <div data-testid="exam-card">
+      <div>{title}</div>
+      <div>{status}</div>
+      <div>{examDetails?.[0]?.description}</div>
+    </div>
+  );
+});
+jest.mock('features/DashboardPage/components/NoContentPlaceholder', () => function ({ title, description }) {
+  return <div data-testid="no-content">{title || description}</div>;
+});
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+describe('DashboardPage', () => {
+  const validExams = [
+    {
+      id: 1,
+      name: 'Exam 1',
+      status: 'APPT_CREATED',
+      vue_appointment_id: 'abc123',
+      created: '2025-07-01T10:00:00Z',
+      start_at: '2025-07-30T18:00:00Z',
+    },
+    {
+      id: 2,
+      name: 'Exam 2',
+      status: 'EXAM_DELIVERED',
+      vue_appointment_id: 'def456',
+      created: '2025-07-01T11:00:00Z',
+      start_at: '2025-07-20T16:30:00Z',
+    },
+    {
+      id: 3,
+      name: 'Canceled Exam',
+      status: 'APPT_CANCELED',
+      vue_appointment_id: 'xyz789',
+      created: '2025-07-01T12:00:00Z',
+    },
+  ];
+
+  const invalidExams = [
+    {
+      id: 4,
+      name: 'Expired Exam',
+      status: 'EXPIRED',
+      created: '2025-07-01T12:00:00Z',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('shows loading spinner initially', async () => {
+    jest.spyOn(api, 'getExams').mockResolvedValueOnce({
+      data: { results: [] },
+    });
+
+    render(<DashboardPage />);
+    expect(screen.getByText(/loading exams/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading exams/i)).not.toBeInTheDocument();
+    });
+  });
+
+  test('renders NoContentPlaceholder when no valid exams', async () => {
+    jest.spyOn(api, 'getExams').mockResolvedValueOnce({
+      data: { results: invalidExams },
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('no-content')).toBeInTheDocument();
+    });
+  });
+
+  test('handles API error and shows placeholder', async () => {
+    jest.spyOn(api, 'getExams').mockRejectedValueOnce(new Error('API failed'));
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('no-content')).toBeInTheDocument();
+    });
+  });
+
+  test('displays correct exam details for scheduled and unscheduled exams', async () => {
+    jest.spyOn(api, 'getExams').mockResolvedValueOnce({
+      data: { results: validExams },
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      const exam1 = screen.getByText('Exam 1');
+      const exam2 = screen.getByText('Exam 2');
+
+      expect(exam1).toBeInTheDocument();
+      expect(exam2).toBeInTheDocument();
+
+      expect(screen.getByText('complete')).toBeInTheDocument();
+      expect(screen.getByText('scheduled')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/SchedulePage/index.jsx
+++ b/src/features/SchedulePage/index.jsx
@@ -3,7 +3,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { Header } from 'react-paragon-topaz';
 import { Container, Toast } from '@edx/paragon';
 
-import { countries } from 'constants';
+import { countries } from 'features/utils/constants';
 import { updateUserData } from 'features/data/api';
 import TermsConditions from 'components/TermsConditions';
 import IdentityForm from 'components/form';

--- a/src/features/data/__test__/api.test.jsx
+++ b/src/features/data/__test__/api.test.jsx
@@ -1,7 +1,7 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
-import { getUserData, updateUserData } from '../api';
+import { getUserData, updateUserData, getExams } from '../api';
 
 jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(),
@@ -44,5 +44,15 @@ describe('API service', () => {
 
     expect(mockHttpClient.post).toHaveBeenCalledWith('https://test.api/cdd/', mockPayload);
     expect(response).toEqual({ status: 200 });
+  });
+
+  test('should call GET with correct URL in getExams', async () => {
+    const mockData = { data: [{ id: 1, name: 'Mock Exam' }] };
+    mockHttpClient.get.mockResolvedValue(mockData);
+
+    const response = await getExams();
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith('https://test.api/exams/');
+    expect(response).toEqual(mockData);
   });
 });

--- a/src/features/data/api.js
+++ b/src/features/data/api.js
@@ -13,3 +13,9 @@ export function updateUserData(userData) {
     userData,
   );
 }
+
+export function getExams() {
+  return getAuthenticatedHttpClient().get(
+    `${getConfig().WEBNG_PLUGIN_API_BASE_URL}/exams/`,
+  );
+}

--- a/src/features/utils/constants.js
+++ b/src/features/utils/constants.js
@@ -25,3 +25,19 @@ export const countries = countriesData
     cca2,
   }))
   .filter(({ dialingCode }) => dialingCode);
+
+export const examStatus = {
+  SCHEDULED: 'scheduled',
+  UNSCHEDULED: 'unscheduled',
+  COMPLETE: 'complete',
+};
+
+/**
+ * Maps backend exam status to status defined for exam cards.
+ * Key: Backend status string from API
+ * Value: status label used for exam cards
+ */
+export const EXAM_STATUS_MAP = {
+  APPT_CREATED: examStatus.SCHEDULED,
+  EXAM_DELIVERED: examStatus.COMPLETE,
+};

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -7,7 +7,6 @@ module.exports = createConfig('webpack-dev', {
       components: path.resolve(__dirname, 'src/components'),
       features: path.resolve(__dirname, 'src/features'),
       assets: path.resolve(__dirname, 'src/assets'),
-      constants: path.resolve(__dirname, 'src/constants'),
     },
   },
   devServer: {

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -7,7 +7,6 @@ module.exports = createConfig('webpack-dev', {
       components: path.resolve(__dirname, 'src/components'),
       features: path.resolve(__dirname, 'src/features'),
       assets: path.resolve(__dirname, 'src/assets'),
-      constants: path.resolve(__dirname, 'src/constants'),
     },
   },
 });


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2429

### Description
Add call services to show exams card in dashboard

### Changes made
Add service to get exams info
Return exams details info depending of exam status
Hide voucher details according to scope define in meeting
Hide status unscheduled and other status to be out of this scope
Update test

### Screenshoot
<img width="920" height="676" alt="Screenshot from 2025-07-10 13-42-25" src="https://github.com/user-attachments/assets/ae40ce73-da27-496d-82db-99f7e00eccc1" />


### How to test
Clone the exam dashboard MFE
Run npm install.
Run npm run start
Go to http://localhost:2005/exam

Define this setting in MFE_CONFIG
WEBNG_PLUGIN_API_BASE_URL='http://localhost:18000/webng_plugin/api/v0'

Add exams from /admin django