### PR TITLE
fix: error handler in cdd workflow

### DIFF
--- a/src/features/SchedulePage/__test__/index.test.jsx
+++ b/src/features/SchedulePage/__test__/index.test.jsx
@@ -1,11 +1,12 @@
 /* eslint-disable func-names, react/prop-types */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import SchedulePage from 'features/SchedulePage';
 
 import { updateUserData } from 'features/data/api';
+import { render } from 'test-utils';
 
 jest.mock('constants', () => ({
   countries: [

--- a/src/features/SchedulePage/index.jsx
+++ b/src/features/SchedulePage/index.jsx
@@ -4,7 +4,7 @@ import { Header } from 'react-paragon-topaz';
 import { Container, Toast } from '@edx/paragon';
 
 import { countries } from 'features/utils/constants';
-import { updateUserData } from 'features/data/api';
+import { updateUserData, getScheduleUrl } from 'features/data/api';
 import TermsConditions from 'components/TermsConditions';
 import IdentityForm from 'components/form';
 
@@ -42,7 +42,15 @@ const SchedulePage = () => {
 
     try {
       await updateUserData(payload);
-      window.location.href = `${getConfig().WEBNG_PLUGIN_API_BASE_URL}/appointment/schedule`;
+      const response = await getScheduleUrl();
+      if (response?.data?.url) {
+        window.location.href = response.data.url;
+      } else {
+        setToast({
+          show: true,
+          message: 'Unexpected response from the server.',
+        });
+      }
     } catch (error) {
       const { customAttributes } = error || {};
       const { httpErrorResponseData, httpErrorStatus } = customAttributes || {};

--- a/src/features/data/api.js
+++ b/src/features/data/api.js
@@ -66,3 +66,15 @@ export async function cancelExam(vueAppointmentId) {
     },
   );
 }
+
+/**
+ * Fetches the schedule URL
+ * @async
+ * @function getScheduleUrl
+ * @returns {Promise<AxiosResponse>} - A promise that resolves to the HTTP response from the backend.
+ */
+export async function getScheduleUrl() {
+  const baseUrl = `${getConfig().WEBNG_PLUGIN_API_BASE_URL}/appointment/schedule`;
+
+  return getAuthenticatedHttpClient().get(baseUrl);
+}


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2629

### Description
Fix error handler in cdd workflow when there is an error with service call

### How to test
Clone the exam dashboard MFE
Run npm install.
Run npm run start
Go to http://localhost:2005/exam

Define this setting in MFE_CONFIG
WEBNG_PLUGIN_API_BASE_URL='http://localhost:18000/webng_plugin/api/v0'
