### PR TITLE
feat: modal with terms and conditions in exam card

### DIFF
--- a/src/components/ExamCard/index.scss
+++ b/src/components/ExamCard/index.scss
@@ -203,3 +203,7 @@ $content-max-height: 250px;
   text-decoration: underline;
   font-weight: 400;
 }
+
+div.hide-overflow-x {
+  overflow-x: hidden;
+}

--- a/src/components/TermsConditions/index.scss
+++ b/src/components/TermsConditions/index.scss
@@ -34,6 +34,10 @@
     margin-left: 1.5rem;
     margin-top: 0.5rem;
   }
+  
+  @media screen and (max-width: 576px) {
+    padding: 1rem;
+  }
 }
 
 .section-buttons {

--- a/src/features/DashboardPage/index.jsx
+++ b/src/features/DashboardPage/index.jsx
@@ -69,7 +69,7 @@ const DashboardPage = () => {
               examDetails={examDetails}
               additionalExamDetails={additionalExamDetails}
               dropdownItems={dropdownItems}
-              hideFooter
+              hideVoucherButton
             />
           );
         })}

--- a/src/features/SchedulePage/index.jsx
+++ b/src/features/SchedulePage/index.jsx
@@ -3,31 +3,11 @@ import { getConfig } from '@edx/frontend-platform';
 import { Header } from 'react-paragon-topaz';
 import { Container, Toast } from '@edx/paragon';
 
-import { countries } from 'features/utils/constants';
+import { formatUserPayload } from 'features/utils/constants';
 import { updateUserData, getScheduleUrl } from 'features/data/api';
+
 import TermsConditions from 'components/TermsConditions';
 import IdentityForm from 'components/form';
-
-const formatUserPayload = (formData) => {
-  const phoneCountryCode = countries.find(
-    (c) => c.cca2 === formData.dialingCode.value,
-  )?.dialingCode?.replace('+', '') || '1';
-
-  return {
-    email: formData.email.value,
-    first_name: formData.firstName.value,
-    last_name: formData.lastName.value,
-    postal_code: formData.postalCode.value,
-    phone_country_code: phoneCountryCode,
-    state: formData.state.value,
-    profile: {
-      country: formData.country.value,
-      city: formData.city.value,
-      mailing_address: formData.address.value,
-      phone_number: formData.phone.value,
-    },
-  };
-};
 
 const SchedulePage = () => {
   const [acceptedTerms, setAcceptedTerms] = useState(false);

--- a/src/features/utils/constants.js
+++ b/src/features/utils/constants.js
@@ -121,4 +121,25 @@ export const EXAM_STATUS_MAP = {
   EXPIRED: examStatus.EXPIRED,
 };
 
-export const EXAMS_AVAILABLE = ['APPT_CREATED', 'EXAM_DELIVERED'];
+export const EXAMS_AVAILABLE = ['APPT_CREATED', 'EXAM_DELIVERED', 'APPT_CANCELED'];
+
+export const formatUserPayload = (formData) => {
+  const phoneCountryCode = countries.find(
+    (c) => c.cca2 === formData.dialingCode.value,
+  )?.dialingCode?.replace('+', '') || '1';
+
+  return {
+    email: formData.email.value,
+    first_name: formData.firstName.value,
+    last_name: formData.lastName.value,
+    postal_code: formData.postalCode.value,
+    phone_country_code: phoneCountryCode,
+    state: formData.state.value,
+    profile: {
+      country: formData.country.value,
+      city: formData.city.value,
+      mailing_address: formData.address.value,
+      phone_number: formData.phone.value,
+    },
+  };
+};

--- a/src/index.scss
+++ b/src/index.scss
@@ -16,3 +16,9 @@
 .pageWrapper{
   background-color: $bg-main-color;
 }
+
+// Remove modal top and bottom shadows
+[dir="ltr"] .pgn__modal-body::after,
+.pgn__modal-body::before {
+  background-image: none;
+}


### PR DESCRIPTION
# Description
This pull request introduces a modal containing the terms and conditions form for exams with the status `APPT_CANCELED`.

## Ticket
https://pearson.atlassian.net/browse/PADV-2198

## Changes
- Added a modal component to the exam card.
- Integrated a terms and conditions form inside the modal.
- Ensured the modal is only available for exams with status `APPT_CANCELED`.

## Screenshots
<img width="2880" height="2202" alt="localhost_2005_dashboard (2)" src="https://github.com/user-attachments/assets/f07befc9-58db-4de9-8a24-3f70160011b4" />
<img width="2880" height="2202" alt="localhost_2005_dashboard (3)" src="https://github.com/user-attachments/assets/02250fc9-52f5-419d-8a91-f7e666a57459" />
<img width="2880" height="2980" alt="localhost_2005_dashboard (4)" src="https://github.com/user-attachments/assets/ef488f3b-185d-489a-822d-51a83bb3fc40" />


## How to test
- Create exams via `django admin` or use this content to override `/exams` response with this content:

```javascript
{
    "next": null,
    "previous": null,
    "count": 6,
    "num_pages": 1,
    "current_page": 1,
    "start": 0,
    "results": [
        {
            "id": 1,
            "result_id": 1,
            "created": "2025-09-01T19:40:13.920093Z",
            "modified": "2025-09-05T18:38:35.735209Z",
            "name": "Scheduled",
            "series_code": "123456",
            "start_at": "2025-09-01T19:40:06Z",
            "duration": 12,
            "status": "APPT_CREATED",
            "vue_appointment_id": 12,
            "candidate": 1,
            "test_center": null
        },
        {
            "id": 2,
            "result_id": null,
            "created": "2025-09-01T19:46:08.052101Z",
            "modified": "2025-09-01T19:46:08.052101Z",
            "name": "Completed",
            "series_code": "123456",
            "start_at": "2025-09-01T19:45:36Z",
            "duration": 1,
            "status": "EXAM_DELIVERED",
            "vue_appointment_id": 1,
            "candidate": 1,
            "test_center": null
        },
        {
            "id": 3,
            "result_id": null,
            "created": "2025-09-02T14:20:36.359860Z",
            "modified": "2025-09-02T14:20:36.359860Z",
            "name": "Expired",
            "series_code": "123456",
            "start_at": "2025-09-02T14:20:28Z",
            "duration": 1,
            "status": "EXPIRED",
            "vue_appointment_id": 3,
            "candidate": 1,
            "test_center": null
        },
        {
            "id": 4,
            "result_id": null,
            "created": "2025-09-02T14:20:55.557554Z",
            "modified": "2025-09-02T14:20:55.557554Z",
            "name": "NDA Refused",
            "series_code": "123456",
            "start_at": "2025-09-02T14:20:50Z",
            "duration": 12,
            "status": "NDA_REFUSED",
            "vue_appointment_id": 4,
            "candidate": 1,
            "test_center": null
        },
        {
            "id": 5,
            "result_id": null,
            "created": "2025-09-02T14:21:14.392776Z",
            "modified": "2025-09-02T14:21:14.392776Z",
            "name": "No Show",
            "series_code": "123456",
            "start_at": "2025-09-02T14:21:08Z",
            "duration": 1,
            "status": "NO_SHOW",
            "vue_appointment_id": 6,
            "candidate": 1,
            "test_center": null
        },
        {
            "id": 6,
            "result_id": null,
            "created": "2025-09-02T14:21:30.982465Z",
            "modified": "2025-09-05T17:45:02.409787Z",
            "name": "Canceled",
            "series_code": "123456",
            "start_at": "2026-08-20T14:21:27Z",
            "duration": 1,
            "status": "APPT_CANCELED",
            "vue_appointment_id": 7,
            "candidate": 1,
            "test_center": null
        }
    ]
}
``` 
