### PR TITLE
fix: footer styles

### DIFF
--- a/src/features/DashboardPage/index.jsx
+++ b/src/features/DashboardPage/index.jsx
@@ -6,7 +6,6 @@ import {
   Spinner,
   Toast,
 } from '@edx/paragon';
-import Header from '@edx/frontend-component-header';
 
 import ExamCard from 'components/ExamCard';
 import NoContentPlaceholder from 'features/DashboardPage/components/NoContentPlaceholder';
@@ -96,7 +95,7 @@ const DashboardPage = () => {
         {toast.message}
       </Toast>
       <div className="dashboard-container mb-5">
-        <Header />
+
         <div className="tabs-container">
           <Tabs id="tabs" variant="button-group" className="tabs-wrapper" activeKey={tab} onSelect={setTab}>
             <Tab

--- a/src/features/Main/__test__/index.test.jsx
+++ b/src/features/Main/__test__/index.test.jsx
@@ -1,17 +1,21 @@
 /* eslint-disable func-names */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
+
+import { render } from 'test-utils';
 
 import Main from 'features/Main';
 
 jest.mock('features/SchedulePage', () => function () {
   return <div>Mocked SchedulePage</div>;
 });
+
 jest.mock('features/DashboardPage', () => function () {
   return <div>Mocked DashboardPage</div>;
 });
+
 jest.mock('@edx/frontend-component-footer', () => function () {
   return <div>Mocked Footer</div>;
 });
@@ -20,6 +24,8 @@ jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(() => ({
     EXAM_DASHBOARD_PATH: '/schedule',
   })),
+  ensureConfig: jest.fn(),
+  subscribe: jest.fn(),
 }));
 
 describe('Main Component ', () => {

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -7,12 +7,14 @@ import {
 } from 'react-router-dom';
 import { getConfig } from '@edx/frontend-platform';
 import Footer from '@edx/frontend-component-footer';
+import Header from '@edx/frontend-component-header';
 
 import SchedulePage from 'features/SchedulePage';
 import DashboardPage from 'features/DashboardPage';
 
 const Main = () => (
   <BrowserRouter basename={getConfig().EXAM_DASHBOARD_PATH}>
+    <Header />
     <Switch>
       <Route path="/exam" component={SchedulePage} />
       <Route path="/dashboard" component={DashboardPage} />

--- a/src/features/SchedulePage/__test__/index.test.jsx
+++ b/src/features/SchedulePage/__test__/index.test.jsx
@@ -27,9 +27,6 @@ jest.mock('features/data/api', () => ({
 }));
 
 jest.mock('react-paragon-topaz', () => ({
-  Header: ({ src, logoUrl }) => (
-    <div data-testid="header" data-src={src} data-url={logoUrl}>Mock Header</div>
-  ),
   Button: () => (
     <div data-testid="button">Button</div>
   ),
@@ -95,10 +92,9 @@ describe('SchedulePage', () => {
     window.location = originalLocation;
   });
 
-  test('renders the header and terms component initially', () => {
+  test('renders the terms component initially', () => {
     render(<SchedulePage />);
 
-    expect(screen.getByTestId('header')).toBeInTheDocument();
     expect(screen.getByTestId('terms')).toBeInTheDocument();
   });
 

--- a/src/features/SchedulePage/index.jsx
+++ b/src/features/SchedulePage/index.jsx
@@ -1,6 +1,4 @@
 import React, { useState } from 'react';
-import { getConfig } from '@edx/frontend-platform';
-import { Header } from 'react-paragon-topaz';
 import { Container, Toast } from '@edx/paragon';
 
 import { formatUserPayload } from 'features/utils/constants';
@@ -54,10 +52,6 @@ const SchedulePage = () => {
         {toast.message}
       </Toast>
       )}
-      <Header
-        src={getConfig().LOGO_URL}
-        logoUrl={getConfig().LMS_BASE_URL}
-      />
       <div className="pageWrapper p-3">
         <Container size="xl" className="bg-white rounded p-0">
           {!acceptedTerms && (


### PR DESCRIPTION
# Description  
This pull request fixes the issue where the footer styles were not being applied correctly. The problem occurred because the footer styles depend on the header being in the correct position in the DOM. Previously, the `header.site-header-desktop` element was located outside of the expected structure, causing the CSS selector `header.site-header-desktop ~ footer` not to match. The header has now been placed correctly so that the footer styles load as intended.  

## Ticket  
https://pearson.atlassian.net/browse/PADV-2644


## Screenshots  
_before:_  
The footer appeared without styles or default browser styles were shown.  
<img width="1913" height="853" alt="Screenshot 2025-09-19 at 10 04 30 AM" src="https://github.com/user-attachments/assets/0a526338-68b1-4454-b5cf-3de494476abc" />


_after:_  
The footer displays with the correct branding and styling.  
<img width="2148" height="3356" alt="localhost_2005_exam" src="https://github.com/user-attachments/assets/5871b8bf-897b-4c2a-a126-6da6051d296a" />


## How to test  
1. Start the application.  
2. Navigate to `/exams` or `/dashboard`.  
3. Verify that the footer is styled correctly and matches the brand styles.  
