### PR TITLE
PADV-2646 - Remove population of profile data except for email

### DIFF
--- a/src/components/ExamCard/index.jsx
+++ b/src/components/ExamCard/index.jsx
@@ -8,15 +8,17 @@ import {
   useToggle,
   IconButton,
   Icon,
-  Toast,
   Dropdown,
 } from '@edx/paragon';
 import { MoreVert } from '@edx/paragon/icons';
 
 import './index.scss';
-import { examStatus, EXAM_STATUS_UI_STYLES, formatUserPayload } from 'features/utils/constants';
-import { redirectToScheduleSSO } from 'features/utils/globals';
-import { updateUserData } from 'features/data/api';
+import {
+  examStatus,
+  EXAM_STATUS_UI_STYLES,
+} from 'features/utils/constants';
+
+import { scheduleExam } from 'features/utils/globals';
 
 import TermsConditions from 'components/TermsConditions';
 import IdentityForm from 'components/form';
@@ -35,7 +37,6 @@ const ExamCard = ({
   const [isTermsOpen, openTerms, closeTerms] = useToggle(false);
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const [isOpen, open, close] = useToggle(false);
-  const [toast, setToast] = useState({ show: false, message: '' });
 
   const {
     text = '',
@@ -48,50 +49,18 @@ const ExamCard = ({
     setAcceptedTerms(false);
   };
 
-  const handleFormSubmit = async (formData) => {
-    const payload = formatUserPayload(formData);
-
-    try {
-      await updateUserData(payload);
-      redirectToScheduleSSO();
-    } catch (error) {
-      const { customAttributes } = error || {};
-      const { httpErrorResponseData, httpErrorStatus } = customAttributes || {};
-
-      if (httpErrorStatus === 400) {
-        setToast({
-          show: true,
-          message: httpErrorResponseData,
-        });
-      } else {
-        setToast({
-          show: true,
-          message: 'Internal server error',
-        });
-      }
-    }
-  };
+  const handleFormSubmit = (formData) => scheduleExam({ formData });
 
   return (
-    <>
-      <Toast
-        onClose={() => setToast(prev => ({ ...prev, show: false }))}
-        dismissible
-        hasCloseButton
-        className="mb-3"
-        show={toast.show}
-      >
-        {toast.message}
-      </Toast>
-      <Col xs={12} md={6} className="mb-4">
-        <Card className="card-wrapper w-100">
-          <div className={`card-header-background ${customClass}`}>
-            <span className={`custom-badge ${badge}`}>{text}</span>
-            {image && <div className="card-header-image" style={{ backgroundImage: `url(${image})` }} />}
-          </div>
-          <div className="card-header-container">
-            <h2 className="px-4 text-truncate custom-card-header">{title}</h2>
-            {
+    <Col xs={12} md={6} className="mb-4">
+      <Card className="card-wrapper w-100">
+        <div className={`card-header-background ${customClass}`}>
+          <span className={`custom-badge ${badge}`}>{text}</span>
+          {image && <div className="card-header-image" style={{ backgroundImage: `url(${image})` }} />}
+        </div>
+        <div className="card-header-container">
+          <h2 className="px-4 text-truncate custom-card-header">{title}</h2>
+          {
             (dropdownItems?.length > 0 && allowedStatuses.includes(status)) && (
               <Dropdown id="dropdown-overlay">
                 <Dropdown.Toggle
@@ -118,19 +87,19 @@ const ExamCard = ({
               </Dropdown>
             )
           }
-          </div>
-          <Card.Section className="px-4">
-            <div className="custom-card-separator" />
-            <ul className="row d-flex flex-column px-1 mb-0" id="exam-details-list">
-              {examDetails.map(({ title: itemTitle, description }) => (
-                <li key={itemTitle} className="mb-2 mb-md-0 d-flex align-items-center list-item text-truncate">
-                  <span className="col-3 col-xxl-2 fw-semibold pr-0 text-truncate" title={itemTitle}>{itemTitle}</span>
-                  <span className="col-sm-10 col-md-9 mb-0 pl-0 custom-text-wrap" title={description}>{description}</span>
-                </li>
-              ))}
-            </ul>
-          </Card.Section>
-          {
+        </div>
+        <Card.Section className="px-4">
+          <div className="custom-card-separator" />
+          <ul className="row d-flex flex-column px-1 mb-0" id="exam-details-list">
+            {examDetails.map(({ title: itemTitle, description }) => (
+              <li key={itemTitle} className="mb-2 mb-md-0 d-flex align-items-center list-item text-truncate">
+                <span className="col-3 col-xxl-2 fw-semibold pr-0 text-truncate" title={itemTitle}>{itemTitle}</span>
+                <span className="col-sm-10 col-md-9 mb-0 pl-0 custom-text-wrap" title={description}>{description}</span>
+              </li>
+            ))}
+          </ul>
+        </Card.Section>
+        {
           (status === examStatus.CANCELED || !hideVoucherButton) && (
             <Card.Footer className="px-4 pb-4 d-flex flex-column">
               <div className="custom-card-separator" />
@@ -147,46 +116,46 @@ const ExamCard = ({
             </Card.Footer>
           )
         }
-        </Card>
-        <ModalDialog
-          title="Voucher Details"
-          isOpen={isOpen}
-          onClose={close}
-          hasCloseButton
-          isFullscreenOnMobile={false}
-          isOverflowVisible={false}
-        >
-          <ModalDialog.Header>
-            <ModalDialog.Title>{title}</ModalDialog.Title>
-          </ModalDialog.Header>
-          <ModalDialog.Body>
-            <ul className="row d-flex flex-column px-1">
-              {additionalExamDetails.map(({ title: detailTitle, description }) => (
-                <li key={detailTitle} className="mb-2 d-flex align-items-center list-item text-truncate">
-                  <span className="col-sm-4 fw-semibold pr-0 text-truncate">{detailTitle}</span>
-                  <span className="col-sm-8 mb-0 pl-0 text-truncate">{description}</span>
-                </li>
-              ))}
-            </ul>
-          </ModalDialog.Body>
-        </ModalDialog>
-        <ModalDialog
-          title=""
-          isOpen={isTermsOpen}
-          onClose={handleOnCancel}
-          hasCloseButton
-          size="xl"
-          isFullscreenOnMobile={false}
-          isOverflowVisible={false}
-        >
-          <ModalDialog.Body className="p-0 py-lg-5 hide-overflow-xp-0 p-lg-5">
-            {!acceptedTerms && (
+      </Card>
+      <ModalDialog
+        title="Voucher Details"
+        isOpen={isOpen}
+        onClose={close}
+        hasCloseButton
+        isFullscreenOnMobile={false}
+        isOverflowVisible={false}
+      >
+        <ModalDialog.Header>
+          <ModalDialog.Title>{title}</ModalDialog.Title>
+        </ModalDialog.Header>
+        <ModalDialog.Body>
+          <ul className="row d-flex flex-column px-1">
+            {additionalExamDetails.map(({ title: detailTitle, description }) => (
+              <li key={detailTitle} className="mb-2 d-flex align-items-center list-item text-truncate">
+                <span className="col-sm-4 fw-semibold pr-0 text-truncate">{detailTitle}</span>
+                <span className="col-sm-8 mb-0 pl-0 text-truncate">{description}</span>
+              </li>
+            ))}
+          </ul>
+        </ModalDialog.Body>
+      </ModalDialog>
+      <ModalDialog
+        title=""
+        isOpen={isTermsOpen}
+        onClose={handleOnCancel}
+        hasCloseButton
+        size="xl"
+        isFullscreenOnMobile={false}
+        isOverflowVisible={false}
+      >
+        <ModalDialog.Body className="p-0 py-lg-5 hide-overflow-xp-0 p-lg-5">
+          {!acceptedTerms && (
             <TermsConditions
               onAccept={() => setAcceptedTerms(true)}
               onCancel={handleOnCancel}
             />
-            )}
-            {acceptedTerms
+          )}
+          {acceptedTerms
             && (
             <IdentityForm
               onSubmit={handleFormSubmit}
@@ -194,10 +163,9 @@ const ExamCard = ({
               onPrevious={() => setAcceptedTerms(false)}
             />
             )}
-          </ModalDialog.Body>
-        </ModalDialog>
-      </Col>
-    </>
+        </ModalDialog.Body>
+      </ModalDialog>
+    </Col>
   );
 };
 

--- a/src/features/SchedulePage/index.jsx
+++ b/src/features/SchedulePage/index.jsx
@@ -1,66 +1,32 @@
 import React, { useState } from 'react';
-import { Container, Toast } from '@edx/paragon';
+import { Container } from '@edx/paragon';
 
-import { formatUserPayload } from 'features/utils/constants';
-import { updateUserData } from 'features/data/api';
-import { redirectToScheduleSSO } from 'features/utils/globals';
+import { scheduleExam } from 'features/utils/globals';
 
 import TermsConditions from 'components/TermsConditions';
 import IdentityForm from 'components/form';
 
 const SchedulePage = () => {
   const [acceptedTerms, setAcceptedTerms] = useState(false);
-  const [toast, setToast] = useState({ show: false, message: '' });
 
   const handleCancelTerms = () => {
     window.location.href = 'https://www.pearsonvue.com/us/en/itspecialist.html';
   };
 
-  const handleFormSubmit = async (formData) => {
-    const payload = formatUserPayload(formData);
-
-    try {
-      await updateUserData(payload);
-      redirectToScheduleSSO();
-    } catch (error) {
-      const { customAttributes } = error || {};
-      const { httpErrorResponseData, httpErrorStatus } = customAttributes || {};
-
-      if (httpErrorStatus === 400) {
-        setToast({
-          show: true,
-          message: httpErrorResponseData,
-        });
-      } else {
-        setToast({
-          show: true,
-          message: 'Internal server error',
-        });
-      }
-    }
-  };
+  const handleFormSubmit = (formData) => scheduleExam({ formData });
 
   return (
-    <>
-      {toast.show && (
-      <Toast
-        onClose={() => setToast(prev => ({ ...prev, show: false }))}
-        dismissible
-        hasCloseButton
-        className="mb-3"
-      >
-        {toast.message}
-      </Toast>
-      )}
-      <div className="pageWrapper p-3">
-        <Container size="xl" className="bg-white rounded p-0">
-          {!acceptedTerms && (
-            <TermsConditions
-              onAccept={() => setAcceptedTerms(true)}
-              onCancel={handleCancelTerms}
-            />
-          )}
-          {acceptedTerms
+    <div className="pageWrapper p-3">
+      <Container size="xl" className="bg-white rounded p-0">
+        {
+          !acceptedTerms && (
+          <TermsConditions
+            onAccept={() => setAcceptedTerms(true)}
+            onCancel={handleCancelTerms}
+          />
+          )
+        }
+        {acceptedTerms
             && (
             <IdentityForm
               onSubmit={handleFormSubmit}
@@ -68,9 +34,8 @@ const SchedulePage = () => {
               onPrevious={() => setAcceptedTerms(false)}
             />
             )}
-        </Container>
-      </div>
-    </>
+      </Container>
+    </div>
   );
 };
 

--- a/src/features/data/__test__/api.test.jsx
+++ b/src/features/data/__test__/api.test.jsx
@@ -1,7 +1,7 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
-import { getUserData, updateUserData, getExams } from '../api';
+import { updateUserData, getExams } from '../api';
 
 jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(),
@@ -25,15 +25,6 @@ describe('API service', () => {
     });
 
     getAuthenticatedHttpClient.mockReturnValue(mockHttpClient);
-  });
-
-  test('should call GET with correct URL in getUserData', async () => {
-    mockHttpClient.get.mockResolvedValue({ data: 'mocked data' });
-
-    const response = await getUserData();
-
-    expect(mockHttpClient.get).toHaveBeenCalledWith('https://test.api/cdd/');
-    expect(response).toEqual({ data: 'mocked data' });
   });
 
   test('should call POST with correct URL and payload in updateUserData', async () => {

--- a/src/features/data/api.js
+++ b/src/features/data/api.js
@@ -1,12 +1,6 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
-export function getUserData() {
-  return getAuthenticatedHttpClient().get(
-    `${getConfig().WEBNG_PLUGIN_API_BASE_URL}/cdd/`,
-  );
-}
-
 export function updateUserData(userData) {
   return getAuthenticatedHttpClient().post(
     `${getConfig().WEBNG_PLUGIN_API_BASE_URL}/cdd/`,

--- a/src/features/utils/globals.js
+++ b/src/features/utils/globals.js
@@ -1,5 +1,7 @@
 import { getConfig } from '@edx/frontend-platform';
-import { SCHEDULE_SSO_ENDPOINT } from 'features/utils/constants';
+
+import { updateUserData } from 'features/data/api';
+import { SCHEDULE_SSO_ENDPOINT, formatUserPayload } from 'features/utils/constants';
 
 /**
  * Redirects the user to the schedule SSO endpoint.
@@ -13,3 +15,20 @@ import { SCHEDULE_SSO_ENDPOINT } from 'features/utils/constants';
 export function redirectToScheduleSSO() {
   window.location.href = `${getConfig().WEBNG_PLUGIN_API_BASE_URL}${SCHEDULE_SSO_ENDPOINT}`;
 }
+
+/**
+ * Submits a form by formatting the payload, updating user data,
+ * fetching a schedule URL, and handling navigation or errors.
+ *
+ * @async
+ * @function scheduleExam
+ * @param {Object} params - The parameters for form submission.
+ * @param {Object} params.formData - The raw form data to be formatted.
+ * @returns {Promise<void>} Resolves when the process completes.
+ */
+export const scheduleExam = async ({ formData }) => {
+  const payload = formatUserPayload(formData);
+  await updateUserData(payload);
+
+  redirectToScheduleSSO();
+};


### PR DESCRIPTION
# Description  
This pull request updates the form behavior regarding user information fields and improves error handling.  

Previously:  
- The first name and last name were prefilled from an API and displayed in their respective inputs, preventing the user from editing them.  
- Validation errors coming from the API were only shown as raw JSON inside a toast, not mapped to the form fields.  

With this change:  
- The API data for user information is no longer used. The inputs are now empty and editable **except for the email input**, so the user can fill in this information directly when completing the form.  
- Validation errors from the API are now parsed and displayed inline on each corresponding input field. Errors are properly formatted (arrays of messages are concatenated into a single line) instead of showing raw JSON. A general toast will still appear for internal server errors or unexpected issues. 
- Is removed the call to `/cdd` now the email is taken from the auth context
- Is removed all code related to the call `/cdd` in order to avoid to keep unused code. 
 
# Ticket  
https://pearson.atlassian.net/browse/PADV-2646  

# Screenshots  
_before:_  
- First name and last name fields were prefilled and disabled, preventing user edits.  
- API errors only appeared as raw JSON in a toast.  

<img width="1913" height="853" alt="Screenshot 2025-09-19 at 10 04 30 AM" src="https://github.com/user-attachments/assets/1ad8fae7-ad9b-4dfd-884a-c39494950013" />  

_after:_  
- Fields are empty and editable by the user.  
- Validation errors are shown inline in the form inputs, with friendly messages instead of raw JSON.  
<img width="1131" height="735" alt="Screenshot 2025-09-25 at 10 38 53 AM" src="https://github.com/user-attachments/assets/386ca042-370e-41a7-9a8a-0c9b9def6a11" />


<img width="774" height="731" alt="Screenshot 2025-09-19 at 8 34 42 PM" src="https://github.com/user-attachments/assets/f8a1850f-afd2-4308-bcdd-07dee0815dd4" />


# How to test  
1. Start the application.  
2. Navigate to `/exam` and open the form.  
3. Alternatively, go to `/dashboard` and open the flow using an exam with status `"canceled"`.  
4. Verify that the fields, except for the email are empty and editable.  
5. Submit the form with missing or invalid values to trigger validation errors.  
6. Check that the errors are shown inline in the corresponding fields, and not only as raw JSON in a toast.  
