### PR TITLE
fix: schedule action

### DIFF
--- a/src/components/ExamCard/index.jsx
+++ b/src/components/ExamCard/index.jsx
@@ -15,7 +15,8 @@ import { MoreVert } from '@edx/paragon/icons';
 
 import './index.scss';
 import { examStatus, EXAM_STATUS_UI_STYLES, formatUserPayload } from 'features/utils/constants';
-import { updateUserData, getScheduleUrl } from 'features/data/api';
+import { redirectToScheduleSSO } from 'features/utils/globals';
+import { updateUserData } from 'features/data/api';
 
 import TermsConditions from 'components/TermsConditions';
 import IdentityForm from 'components/form';
@@ -52,15 +53,7 @@ const ExamCard = ({
 
     try {
       await updateUserData(payload);
-      const response = await getScheduleUrl();
-      if (response?.data?.url) {
-        window.location.href = response.data.url;
-      } else {
-        setToast({
-          show: true,
-          message: 'Unexpected response from the server.',
-        });
-      }
+      redirectToScheduleSSO();
     } catch (error) {
       const { customAttributes } = error || {};
       const { httpErrorResponseData, httpErrorStatus } = customAttributes || {};

--- a/src/features/SchedulePage/index.jsx
+++ b/src/features/SchedulePage/index.jsx
@@ -4,7 +4,8 @@ import { Header } from 'react-paragon-topaz';
 import { Container, Toast } from '@edx/paragon';
 
 import { formatUserPayload } from 'features/utils/constants';
-import { updateUserData, getScheduleUrl } from 'features/data/api';
+import { updateUserData } from 'features/data/api';
+import { redirectToScheduleSSO } from 'features/utils/globals';
 
 import TermsConditions from 'components/TermsConditions';
 import IdentityForm from 'components/form';
@@ -22,15 +23,7 @@ const SchedulePage = () => {
 
     try {
       await updateUserData(payload);
-      const response = await getScheduleUrl();
-      if (response?.data?.url) {
-        window.location.href = response.data.url;
-      } else {
-        setToast({
-          show: true,
-          message: 'Unexpected response from the server.',
-        });
-      }
+      redirectToScheduleSSO();
     } catch (error) {
       const { customAttributes } = error || {};
       const { httpErrorResponseData, httpErrorStatus } = customAttributes || {};

--- a/src/features/data/api.js
+++ b/src/features/data/api.js
@@ -78,15 +78,3 @@ export async function cancelExam(vueAppointmentId) {
     },
   );
 }
-
-/**
- * Fetches the schedule URL
- * @async
- * @function getScheduleUrl
- * @returns {Promise<AxiosResponse>} - A promise that resolves to the HTTP response from the backend.
- */
-export async function getScheduleUrl() {
-  const baseUrl = `${getConfig().WEBNG_PLUGIN_API_BASE_URL}/appointment/schedule`;
-
-  return getAuthenticatedHttpClient().get(baseUrl);
-}

--- a/src/features/utils/constants.js
+++ b/src/features/utils/constants.js
@@ -2,6 +2,8 @@ import provinces from 'provinces-ca';
 import states from 'states-us';
 import countriesData from 'world-countries';
 
+export const SCHEDULE_SSO_ENDPOINT = '/appointment/schedule/';
+
 export const canadianProvincesAndTerritories = provinces.map(
   ({ name, abbreviation }) => ({
     label: name,

--- a/src/features/utils/globals.js
+++ b/src/features/utils/globals.js
@@ -1,0 +1,15 @@
+import { getConfig } from '@edx/frontend-platform';
+import { SCHEDULE_SSO_ENDPOINT } from 'features/utils/constants';
+
+/**
+ * Redirects the user to the schedule SSO endpoint.
+ *
+ * Instead of performing an HTTP request, this function directly updates
+ * `window.location.href` with the schedule endpoint URL.
+ *
+ * @function redirectToScheduleSSO
+ * @returns {void} - This function does not return a value, it triggers a page navigation.
+ */
+export function redirectToScheduleSSO() {
+  window.location.href = `${getConfig().WEBNG_PLUGIN_API_BASE_URL}${SCHEDULE_SSO_ENDPOINT}`;
+}


### PR DESCRIPTION
# Description  
This pull request fixes the behavior of the schedule action. Previously, the call to the `/schedule` API incorrectly assumed that the response would include an object containing a new URL value. This assumption was wrong, and it caused issues. Additionally, the API required the request to be made with a trailing slash (`/`) to avoid CORS errors. The request has been corrected so that it now calls `/schedule/` instead of `/schedule`, resolving the issue.  

_before:_  
The `/schedule` request failed due to CORS errors and incorrect assumptions about the response format.  

_after:_  
The `/schedule/` request succeeds and returns the expected response without CORS issues.  

# Ticket  
https://pearson.atlassian.net/browse/PADV-2688

# How to test  
1. Start the application.  
2. Navigate to `/exam` and use the form.  
3. Alternatively, go to `/dashboard` and open the flow using an exam with status `"canceled"`.  
4. Verify that the schedule action works correctly and no CORS error is raised.  
