### PR TITLE
PADV-2641: Update text on "identity verification" screen

### DIFF
--- a/src/components/form/__test__/index.test.jsx
+++ b/src/components/form/__test__/index.test.jsx
@@ -174,7 +174,8 @@ describe('IdentityForm', () => {
       render(<IdentityForm {...mockProps} />);
 
       expect(screen.getByText('Verify your identity')).toBeInTheDocument();
-      expect(screen.getByText('For security reasons, we need the following information to verify your identity.')).toBeInTheDocument();
+      expect(screen.getByText('IMPORTANT: You must enter your first/given and last/surname/family name exactly as it appears on the identification (ID) you will present at the test center.')).toBeInTheDocument();
+      expect(screen.getByText('If there is not an exact match, you will not be able to take your test and you will not be reimbursed for any fees paid.')).toBeInTheDocument();
       expect(screen.getByLabelText('First Name *')).toBeInTheDocument();
       expect(screen.getByLabelText('Last Name *')).toBeInTheDocument();
       expect(screen.getByLabelText('Email *')).toBeInTheDocument();

--- a/src/components/form/index.jsx
+++ b/src/components/form/index.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Form, Toast } from '@edx/paragon';
+import { Form, Toast, Icon } from '@edx/paragon';
 import { Button } from 'react-paragon-topaz';
 import { logError } from '@edx/frontend-platform/logging';
 import { AppContext } from '@edx/frontend-platform/react';
+import { WarningFilled } from '@edx/paragon/icons';
 
 import { Input, PhoneInput, SelectInput } from 'components/form/components';
 import { countries, unitedStates, canadianProvincesAndTerritories } from 'features/utils/constants';
@@ -33,8 +34,17 @@ const countriesWithStates = [UNITED_STATES, CANADA];
 
 const FormHeader = () => (
   <Form.Row className="flex-column mb-4 pl-1">
-    <h3 className="form-title">Verify your identity</h3>
-    <p className="form-subtitle">For security reasons, we need the following information to verify your identity.</p>
+    <h3 className="form-title mb-4">Verify your identity</h3>
+    <p className="form-subtitle">
+      <Icon src={WarningFilled} className="align-middle mr-1 text-danger icon-header" />
+      <strong className="pl-4">
+        IMPORTANT: You must enter your first/given and last/surname/family name exactly as it appears
+        on the identification (ID) you will present at the test center.
+      </strong>
+      <br />
+      If there is not an exact match, you will not be able to take your test and
+      you will not be reimbursed for any fees paid.
+    </p>
   </Form.Row>
 );
 

--- a/src/components/form/index.scss
+++ b/src/components/form/index.scss
@@ -63,3 +63,13 @@
   position: relative;
   left: -15px;
 }
+
+.icon-header {
+  position: absolute;
+  top: 20px;
+  right: 3px;
+}
+
+.pgn__icon.icon-header {
+  height: 20px;
+}


### PR DESCRIPTION
## Tickets

- https://pearson.atlassian.net/browse/PADV-2641

## Description

This PR updates the text on the "identity verification" screen, the text was updated to warn users to make sure their first name and last name matches their identification ID to avoid issues when presenting their ID at the test center.

## Screenshots

<img width="1585" height="790" alt="Screenshot 2025-10-01 at 18 47 39" src="https://github.com/user-attachments/assets/95c0c453-22c0-4d50-ac5c-d3718a6ff37d" />

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Run the MFE: `npm runs start`.
3. Go to the Exam URL: http://localhost:2005/exam
4. Accept the terms and conditions.
5. The new text should be seen at the top of the form bellow the "Verify your identity" title.