### PR TITLE
PADV-2720: Conditionally display 'View Score Report' based on exam result 

### DIFF
--- a/src/features/DashboardPage/__test__/index.test.jsx
+++ b/src/features/DashboardPage/__test__/index.test.jsx
@@ -41,50 +41,50 @@ jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));
 
+const examLocation = {
+  test_center: {
+    test_center_name: 'Alpha Center',
+    test_center_address: {
+      address1: '123 Main St',
+      city: 'Sarajevo',
+      state: '',
+      postal_code: null,
+      country: 'Bosnia',
+    },
+  },
+};
+
+const validExams = [
+  {
+    id: 1,
+    name: 'Exam 1',
+    status: 'APPT_CREATED',
+    vue_appointment_id: 'abc123',
+    created: '2025-07-01T10:00:00Z',
+    start_at: '2025-07-30T18:00:00Z',
+    ...examLocation,
+  },
+  {
+    id: 2,
+    name: 'Exam 2',
+    status: 'EXAM_DELIVERED',
+    vue_appointment_id: 'def456',
+    created: '2025-07-01T11:00:00Z',
+    start_at: '2025-07-20T16:30:00Z',
+    ...examLocation,
+  },
+  {
+    id: 3,
+    name: 'Canceled Exam',
+    status: 'APPT_CANCELED',
+    vue_appointment_id: 'xyz789',
+    created: '2025-07-01T12:00:00Z',
+    start_at: '2025-07-20T16:30:00Z',
+    ...examLocation,
+  },
+];
+
 describe('DashboardPage', () => {
-  const examLocation = {
-    test_center: {
-      test_center_name: 'Alpha Center',
-      test_center_address: {
-        address1: '123 Main St',
-        city: 'Sarajevo',
-        state: '',
-        postal_code: null,
-        country: 'Bosnia',
-      },
-    },
-  };
-
-  const validExams = [
-    {
-      id: 1,
-      name: 'Exam 1',
-      status: 'APPT_CREATED',
-      vue_appointment_id: 'abc123',
-      created: '2025-07-01T10:00:00Z',
-      start_at: '2025-07-30T18:00:00Z',
-      ...examLocation,
-    },
-    {
-      id: 2,
-      name: 'Exam 2',
-      status: 'EXAM_DELIVERED',
-      vue_appointment_id: 'def456',
-      created: '2025-07-01T11:00:00Z',
-      start_at: '2025-07-20T16:30:00Z',
-      ...examLocation,
-    },
-    {
-      id: 3,
-      name: 'Canceled Exam',
-      status: 'APPT_CANCELED',
-      vue_appointment_id: 'xyz789',
-      created: '2025-07-01T12:00:00Z',
-      start_at: '2025-07-20T16:30:00Z',
-      ...examLocation,
-    },
-  ];
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -142,6 +142,59 @@ describe('DashboardPage', () => {
       expect(screen.getAllByText('scheduled')).toHaveLength(2);
     });
   });
+});
+
+describe('Exam actions', () => {
+  test('Should show view score option for completed exam if the result is available', async () => {
+    const scheduledExam = [
+      {
+        id: 11,
+        name: 'Completed Exam',
+        status: 'EXAM_DELIVERED',
+        vue_appointment_id: 'drop123',
+        created: '2025-08-10T10:14:50Z',
+        start_at: '2025-08-15T14:10:00Z',
+        result_id: 1,
+        ...examLocation,
+      },
+    ];
+
+    jest.spyOn(api, 'getExams').mockResolvedValueOnce({
+      data: { results: scheduledExam },
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('complete')).toHaveLength(2);
+      expect(screen.getAllByText('View Score Report')).toHaveLength(2);
+    });
+  });
+
+  test('Should not show view score option for completed exam if the result is NOT available', async () => {
+    const scheduledExam = [
+      {
+        id: 11,
+        name: 'Completed Exam',
+        status: 'EXAM_DELIVERED',
+        vue_appointment_id: 'drop123',
+        created: '2025-08-10T10:14:50Z',
+        start_at: '2025-08-15T14:10:00Z',
+        ...examLocation,
+      },
+    ];
+
+    jest.spyOn(api, 'getExams').mockResolvedValueOnce({
+      data: { results: scheduledExam },
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('complete')).toHaveLength(2);
+      expect(screen.queryByText('View Score Report')).not.toBeInTheDocument();
+    });
+  });
 
   test('Should show cancel option for scheduled exam', async () => {
     const scheduledExam = [
@@ -165,31 +218,6 @@ describe('DashboardPage', () => {
     await waitFor(() => {
       expect(screen.getAllByText('scheduled')).toHaveLength(2);
       expect(screen.getAllByText('Cancel Exam')).toHaveLength(2);
-    });
-  });
-
-  test('Should show view score option for completed exam', async () => {
-    const scheduledExam = [
-      {
-        id: 11,
-        name: 'Completed Exam',
-        status: 'EXAM_DELIVERED',
-        vue_appointment_id: 'drop123',
-        created: '2025-08-10T10:14:50Z',
-        start_at: '2025-08-15T14:10:00Z',
-        ...examLocation,
-      },
-    ];
-
-    jest.spyOn(api, 'getExams').mockResolvedValueOnce({
-      data: { results: scheduledExam },
-    });
-
-    render(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(screen.getAllByText('complete')).toHaveLength(2);
-      expect(screen.getAllByText('View Score Report')).toHaveLength(2);
     });
   });
 

--- a/src/features/utils/examDetailsHandlers.js
+++ b/src/features/utils/examDetailsHandlers.js
@@ -95,11 +95,13 @@ const handlers = {
         { title: 'Issue date: ', description: createdDate },
       ],
       dropdownItems: [
-        {
-          label: 'View Score Report',
-          disabled: exams.find((e) => e.vue_appointment_id === exam.vue_appointment_id)?.loadingScoreReport,
-          onClick: () => actions.handleGetScoreReportUrl?.(exam.vue_appointment_id),
-        },
+        ...(exam?.result_id
+          ? [{
+            label: 'View Score Report',
+            disabled: exams.find((e) => e.vue_appointment_id === exam.vue_appointment_id)?.loadingScoreReport,
+            onClick: () => actions.handleGetScoreReportUrl?.(exam.vue_appointment_id),
+          }]
+          : []),
       ],
     };
   },


### PR DESCRIPTION
# Description

This PR updates the exam dropdown menu to dynamically display the **"View Score Report"** option only when a `result_id` is available for the exam.  

Previously, the option was always shown regardless of availability.  

## Ticket
https://pearson.atlassian.net/browse/PADV-2720

## Screenshots
_With `result_id`_
<img width="587" height="527" alt="Screenshot 2025-10-02 at 5 40 04 PM" src="https://github.com/user-attachments/assets/2097e44a-45c2-490f-bf87-a2e6f4df6b02" />

_Without `result_id`_
<img width="601" height="536" alt="Screenshot 2025-10-02 at 5 40 19 PM" src="https://github.com/user-attachments/assets/ebd16a38-1b13-44ef-ac10-58dd06103ca3" />


## How to test

1. Navigate to the Dashboard page with completed exams.
2. Verify that:
   - Exams **with a `result_id`** show the **"View Score Report"** option in the dropdown.
   - Exams **without a `result_id`** do **not** show the option.

