### PR TITLE
PADV-3049 - Fix phone number code validation

### DIFF
--- a/src/components/form/__test__/index.test.jsx
+++ b/src/components/form/__test__/index.test.jsx
@@ -348,6 +348,11 @@ describe('IdentityForm', () => {
       const firstNameInput = screen.getByLabelText('First Name *');
       const lastNameInput = screen.getByLabelText('Last Name *');
       const emailInput = screen.getByLabelText('Email *');
+      const [dialingCodeSelect] = screen.getAllByRole('combobox');
+
+      fireEvent.change(dialingCodeSelect, {
+        target: { value: 'CA' },
+      });
 
       fireEvent.change(firstNameInput, { target: { value: 'John' } });
       fireEvent.change(lastNameInput, { target: { value: 'Doe' } });
@@ -361,6 +366,7 @@ describe('IdentityForm', () => {
           firstName: expect.objectContaining({ value: 'John' }),
           lastName: expect.objectContaining({ value: 'Doe' }),
           email: expect.objectContaining({ value: 'john@example.com' }),
+          dialingCode: expect.objectContaining({ value: 'CA' }),
         }),
       );
     });

--- a/src/components/form/components/index.jsx
+++ b/src/components/form/components/index.jsx
@@ -112,11 +112,12 @@ export const PhoneInput = ({
           <Select
             label="Dialing code"
             className="form-input"
-            placeholder="Select"
+            placeholder="Dialing code *"
             options={parsedPhoneCountries}
             value={parsedPhoneCountries?.find((c) => c.value === dialingCodeValue)}
             onChange={(opt) => onDialingCodeChange(opt?.value || '')}
             isClearable
+            required
             isDisabled={dialingCodeDisabled || isLoading}
             styles={{
               control: (base) => ({
@@ -125,6 +126,7 @@ export const PhoneInput = ({
                 borderRight: 'none',
                 borderTopRightRadius: 0,
                 borderBottomRightRadius: 0,
+                ...((dialingCodeError || phoneError) && { borderColor: 'var(--error-border-color)' }),
               }),
             }}
           />
@@ -141,13 +143,15 @@ export const PhoneInput = ({
             onChange={(e) => onPhoneChange(e.target.value)}
             required
           />
-          {(phoneError || dialingCodeError) && (
-            <Form.Control.Feedback type="invalid">
-              {phoneError || dialingCodeError}
-            </Form.Control.Feedback>
-          )}
         </Col>
       </div>
+      {(dialingCodeError || phoneError) && (
+        <Form.Control.Feedback type="invalid" className="mt-1">
+          {dialingCodeError}
+          {' '}
+          {phoneError}
+        </Form.Control.Feedback>
+      )}
     </Form.Row>
   </Form.Group>
 );

--- a/src/components/form/index.jsx
+++ b/src/components/form/index.jsx
@@ -88,7 +88,7 @@ const initialFormState = {
   firstName: { isDisabled: false, value: '', error: null },
   lastName: { isDisabled: false, value: '', error: null },
   email: { isDisabled: false, value: '', error: null },
-  dialingCode: { isDisabled: false, value: UNITED_STATES, error: null },
+  dialingCode: { isDisabled: false, value: null, error: null },
   phone: { isDisabled: false, value: '', error: null },
   address: { isDisabled: false, value: '', error: null },
   apartment: { isDisabled: false, value: '', error: null },
@@ -168,6 +168,20 @@ const IdentityForm = ({
   const handleSubmit = async (e) => {
     setIsLoading(true);
     e.preventDefault();
+
+    if (!formData.dialingCode.value) {
+      setFormData({
+        ...formData,
+        dialingCode: {
+          ...formData.dialingCode,
+          error: 'Dialing code is required.',
+        },
+      });
+
+      setIsLoading(false);
+      return;
+    }
+
     try {
       await onSubmit(formData);
     } catch (error) {

--- a/src/components/form/index.scss
+++ b/src/components/form/index.scss
@@ -1,5 +1,14 @@
 @import 'react-paragon-topaz/src/variables.scss';
 
+:root {
+  // This is defined as a CSS variable instead of a Sass variable because
+  // Sass variables are resolved at build time and cannot be accessed from
+  // JavaScript or inline styles in React. CSS variables exist at runtime,
+  // which allows React components (e.g. react-select styles) to reference
+  // the same design token dynamically without duplicating values.
+  --error-border-color: #da3100;
+}
+
 .form-wrapper {
   background-color: #fff;
   border-radius: 8px;
@@ -44,7 +53,7 @@
 }
 
 .form-input input.form-control.is-invalid {
-  border-color: #da3100;
+  border-color: var(--error-border-color);
 }
 
 .form-input input.form-control:hover {


### PR DESCRIPTION
# PR Summary

This PR improves the validation logic for the phone dialing code field in the form.

## Ticket
https://pearson.atlassian.net/browse/PADV-3049

## What changed
- The **dialing code is now mandatory**.
- Removed the previous default value (United States).
- Users must explicitly select a dialing code before submitting the form.
- Added clear **validation feedback** when the dialing code is missing or invalid.
- Updated and fixed existing tests to reflect the new required behavior.

## Screenshots
### Before
<img width="749" height="116" alt="Screenshot 2026-01-23 at 8 57 52 AM" src="https://github.com/user-attachments/assets/8fa76351-e85c-4d66-aacf-25a2b78d0b46" />

### After
_Basic HTML validation_
<img width="744" height="134" alt="Screenshot 2026-01-23 at 8 58 25 AM" src="https://github.com/user-attachments/assets/334a6694-7c9f-482b-83e6-93eb35984ffb" />

_Missing phone_
<img width="756" height="114" alt="Screenshot 2026-01-23 at 8 58 40 AM" src="https://github.com/user-attachments/assets/72f8626b-931b-45ef-aa66-a3083346a096" />

_Form dialing code validation_
<img width="732" height="110" alt="Screenshot 2026-01-23 at 9 00 20 AM" src="https://github.com/user-attachments/assets/f36cd82a-901d-49f9-a7ac-9b5eaec8f1fb" />

_Missing dialing code and phone_
<img width="721" height="110" alt="Screenshot 2026-01-23 at 9 00 40 AM" src="https://github.com/user-attachments/assets/38625ad2-7238-4539-8893-2b52b92a6aec" />


## How to test
- Go to `/exams` and use the form
