### PR TITLE
PADV-3169 - Improve fix phone number code field

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -27,3 +27,5 @@ $bg-tab-notification: #C2E9EA;
 $tab-notification-color: #333333;
 
 $error-text-color: #555;
+
+$border-form-color: #ced4da;

--- a/src/components/form/__test__/index.test.jsx
+++ b/src/components/form/__test__/index.test.jsx
@@ -20,7 +20,7 @@ jest.mock('react-paragon-topaz', () => {
   const PropTypes = require('prop-types');
 
   const Select = ({
-    label, placeholder, options, value, onChange, isDisabled, isClearable, className,
+    label, placeholder, options, value, onChange, isDisabled, className,
   }) => {
     const id = (label || placeholder || 'select')
       .toLowerCase()
@@ -47,15 +47,6 @@ jest.mock('react-paragon-topaz', () => {
             </option>
           ))}
         </select>
-        {isClearable && value && (
-          <button
-            type="button"
-            onClick={() => onChange?.(null)}
-            data-testid={`clear-${id}`}
-          >
-            Clear
-          </button>
-        )}
       </div>
     );
   };
@@ -73,7 +64,6 @@ jest.mock('react-paragon-topaz', () => {
     }),
     onChange: PropTypes.func,
     isDisabled: PropTypes.bool,
-    isClearable: PropTypes.bool,
     className: PropTypes.string,
   };
 
@@ -84,7 +74,6 @@ jest.mock('react-paragon-topaz', () => {
     value: null,
     onChange: () => {},
     isDisabled: false,
-    isClearable: false,
     className: '',
   };
 
@@ -125,36 +114,22 @@ jest.mock('react-paragon-topaz', () => {
 jest.mock('constants', () => ({
   countries: [
     {
-      name: 'United States of America',
-      flag: '🇺🇸',
-      dialingCode: '+1',
-      cca3: 'USA',
-      cca2: 'US',
+      name: 'United States', flag: '🇺🇸', dialingCode: '+1', cca3: 'USA', cca2: 'US',
     },
     {
-      name: 'Canada',
-      flag: '🇨🇦',
-      dialingCode: '+1',
-      cca3: 'CAN',
-      cca2: 'CA',
+      name: 'Canada', flag: '🇨🇦', dialingCode: '+1', cca3: 'CAN', cca2: 'CA',
     },
     {
-      name: 'Mexico',
-      flag: '🇲🇽',
-      dialingCode: '+52',
-      cca3: 'MEX',
-      cca2: 'ME',
+      name: 'Mexico', flag: '🇲🇽', dialingCode: '+52', cca3: 'MEX', cca2: 'ME',
     },
   ],
   unitedStates: [
     { label: 'California', value: 'CA' },
     { label: 'New York', value: 'NY' },
-    { label: 'Texas', value: 'TX' },
   ],
   canadianProvincesAndTerritories: [
     { label: 'Ontario', value: 'ON' },
     { label: 'Quebec', value: 'QC' },
-    { label: 'British Columbia', value: 'BC' },
   ],
 }));
 
@@ -170,326 +145,109 @@ describe('IdentityForm', () => {
   });
 
   describe('Initial Rendering', () => {
-    test('renders the component with basic elements', () => {
+    test('renders base fields', () => {
       render(<IdentityForm {...mockProps} />);
 
-      expect(screen.getByText('Verify your identity')).toBeInTheDocument();
-      expect(screen.getByText('IMPORTANT: You must enter your first/given and last/surname/family name exactly as it appears on the identification (ID) you will present at the test center.')).toBeInTheDocument();
-      expect(screen.getByText('If there is not an exact match, you will not be able to take your test and you will not be reimbursed for any fees paid.')).toBeInTheDocument();
       expect(screen.getByLabelText('First Name *')).toBeInTheDocument();
       expect(screen.getByLabelText('Last Name *')).toBeInTheDocument();
       expect(screen.getByLabelText('Email *')).toBeInTheDocument();
-      expect(screen.getByLabelText('Address *')).toBeInTheDocument();
-      expect(screen.getByLabelText('City *')).toBeInTheDocument();
     });
 
-    test('renders all buttons', () => {
+    test('has correct initial values', () => {
       render(<IdentityForm {...mockProps} />);
 
-      expect(screen.getByTestId('button-cancel')).toBeInTheDocument();
-      expect(screen.getByTestId('button-previous')).toBeInTheDocument();
-      expect(screen.getByTestId('button-submit')).toBeInTheDocument();
-    });
-
-    test('renders with empty values by default', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      expect(screen.getByLabelText('First Name *')).toHaveValue('');
-      expect(screen.getByLabelText('Last Name *')).toHaveValue('');
-      expect(screen.getByLabelText('Email *')).toHaveValue('');
+      expect(screen.getByTestId('select-input-country--region')).toHaveValue('USA');
+      expect(screen.getByTestId('select-input-dialing-code')).toHaveValue('US');
     });
   });
 
-  describe('Text Field Interactions', () => {
-    test('updates first name value when changed', () => {
+  describe('Conditional Fields (updated behavior)', () => {
+    test('state and postal enabled for USA', () => {
       render(<IdentityForm {...mockProps} />);
 
-      const firstNameInput = screen.getByLabelText('First Name *');
-      fireEvent.change(firstNameInput, { target: { value: 'John' } });
+      const state = screen.getByTestId('select-input-state--province');
+      const postal = screen.getByLabelText('ZIP / Postal Code *');
 
-      expect(firstNameInput).toHaveValue('John');
+      expect(state).not.toBeDisabled();
+      expect(postal).not.toBeDisabled();
     });
 
-    test('updates last name value when changed', () => {
+    test('state and postal enabled for Canada', () => {
       render(<IdentityForm {...mockProps} />);
 
-      const lastNameInput = screen.getByLabelText('Last Name *');
-      fireEvent.change(lastNameInput, { target: { value: 'Doe' } });
-
-      expect(lastNameInput).toHaveValue('Doe');
-    });
-
-    test('updates email value when changed', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const emailInput = screen.getByLabelText('Email *');
-      fireEvent.change(emailInput, { target: { value: 'john@example.com' } });
-
-      expect(emailInput).toHaveValue('john@example.com');
-    });
-
-    test('updates address value when changed', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const addressInput = screen.getByLabelText('Address *');
-      fireEvent.change(addressInput, { target: { value: '123 Main St' } });
-
-      expect(addressInput).toHaveValue('123 Main St');
-    });
-
-    test('updates apartment value when changed', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const apartmentInput = screen.getByLabelText('Apt #, Suite, Floor');
-      fireEvent.change(apartmentInput, { target: { value: 'Apt 2B' } });
-
-      expect(apartmentInput).toHaveValue('Apt 2B');
-    });
-
-    test('updates city value when changed', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const cityInput = screen.getByLabelText('City *');
-      fireEvent.change(cityInput, { target: { value: 'New York' } });
-
-      expect(cityInput).toHaveValue('New York');
-    });
-
-    test('updates phone value when changed', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const phoneInput = screen.getByLabelText('(555) 555-5555');
-      fireEvent.change(phoneInput, { target: { value: '5551234567' } });
-
-      expect(phoneInput).toHaveValue('5551234567');
-    });
-  });
-
-  describe('Select Fields', () => {
-    test('updates country when selected', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const countrySelect = screen.getByTestId('select-input-country--region');
-      fireEvent.change(countrySelect, { target: { value: 'USA' } });
-
-      expect(countrySelect).toHaveValue('USA');
-    });
-
-    test('updates dialing code when selected', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const dialingCodeSelect = screen.getByTestId('select-input-dialing-code');
-      fireEvent.change(dialingCodeSelect, { target: { value: 'CA' } });
-
-      expect(dialingCodeSelect).toHaveValue('CA');
-    });
-  });
-
-  describe('Conditional Fields for Countries with States', () => {
-    test('displays state and postal code fields when country is United States', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const countrySelect = screen.getByTestId('select-input-country--region');
-      fireEvent.change(countrySelect, { target: { value: 'USA' } });
-
-      expect(screen.getByTestId('select-input-state--province')).toBeInTheDocument();
-      expect(screen.getByLabelText('ZIP / Postal Code *')).toBeInTheDocument();
-    });
-
-    test('displays state and postal code fields when country is Canada', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const countrySelect = screen.getByTestId('select-input-country--region');
-      fireEvent.change(countrySelect, { target: { value: 'CAN' } });
-
-      expect(screen.getByTestId('select-input-state--province')).toBeInTheDocument();
-      expect(screen.getByLabelText('ZIP / Postal Code *')).toBeInTheDocument();
-    });
-
-    test('does not display state and postal code fields for other countries', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const countrySelect = screen.getByTestId('select-input-country--region');
-      fireEvent.change(countrySelect, { target: { value: 'MEX' } });
-
-      expect(screen.queryByTestId('select-input-state--province')).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('ZIP / Postal Code *')).not.toBeInTheDocument();
-    });
-
-    test('can select a state when country is United States', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const countrySelect = screen.getByTestId('select-input-country--region');
-      fireEvent.change(countrySelect, { target: { value: 'USA' } });
-
-      const stateSelect = screen.getByTestId('select-input-state--province');
-      fireEvent.change(stateSelect, { target: { value: 'CA' } });
-
-      expect(stateSelect).toHaveValue('CA');
-    });
-
-    test('can select a province when country is Canada', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const countrySelect = screen.getByTestId('select-input-country--region');
-      fireEvent.change(countrySelect, { target: { value: 'CAN' } });
-
-      const stateSelect = screen.getByTestId('select-input-state--province');
-      fireEvent.change(stateSelect, { target: { value: 'ON' } });
-
-      expect(stateSelect).toHaveValue('ON');
-    });
-  });
-
-  describe('Form Submission', () => {
-    test('calls onSubmit with form data when submitted', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const firstNameInput = screen.getByLabelText('First Name *');
-      const lastNameInput = screen.getByLabelText('Last Name *');
-      const emailInput = screen.getByLabelText('Email *');
-      const [dialingCodeSelect] = screen.getAllByRole('combobox');
-
-      fireEvent.change(dialingCodeSelect, {
-        target: { value: 'CA' },
+      fireEvent.change(screen.getByTestId('select-input-country--region'), {
+        target: { value: 'CAN' },
       });
 
-      fireEvent.change(firstNameInput, { target: { value: 'John' } });
-      fireEvent.change(lastNameInput, { target: { value: 'Doe' } });
-      fireEvent.change(emailInput, { target: { value: 'john@example.com' } });
+      const state = screen.getByTestId('select-input-state--province');
+      const postal = screen.getByLabelText('ZIP / Postal Code *');
 
-      const submitButton = screen.getByTestId('button-submit');
-      fireEvent.click(submitButton);
-
-      expect(mockProps.onSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          firstName: expect.objectContaining({ value: 'John' }),
-          lastName: expect.objectContaining({ value: 'Doe' }),
-          email: expect.objectContaining({ value: 'john@example.com' }),
-          dialingCode: expect.objectContaining({ value: 'CA' }),
-        }),
-      );
+      expect(state).not.toBeDisabled();
+      expect(postal).not.toBeDisabled();
     });
 
-    test('prevents default form behavior on submission', () => {
+    test('state and postal disabled for other countries', () => {
       render(<IdentityForm {...mockProps} />);
 
-      const form = screen.getByRole('form');
-      const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+      fireEvent.change(screen.getByTestId('select-input-country--region'), {
+        target: { value: 'MEX' },
+      });
 
-      fireEvent(form, submitEvent);
+      const state = screen.getByTestId('select-input-state--province');
+      const postal = screen.getByLabelText('ZIP / Postal Code *');
 
-      expect(submitEvent.defaultPrevented).toBe(true);
+      expect(state).toBeDisabled();
+      expect(postal).toBeDisabled();
     });
   });
 
-  describe('Button Events', () => {
-    test('calls onCancel and resets form when Cancel is clicked', () => {
+  describe('Interactions', () => {
+    test('updates text inputs', () => {
       render(<IdentityForm {...mockProps} />);
 
-      const firstNameInput = screen.getByLabelText('First Name *');
-      fireEvent.change(firstNameInput, { target: { value: 'John' } });
+      const input = screen.getByLabelText('First Name *');
+      fireEvent.change(input, { target: { value: 'John' } });
 
-      const cancelButton = screen.getByTestId('button-cancel');
-      fireEvent.click(cancelButton);
+      expect(input).toHaveValue('John');
+    });
 
+    test('updates select', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      const select = screen.getByTestId('select-input-country--region');
+      fireEvent.change(select, { target: { value: 'CAN' } });
+
+      expect(select).toHaveValue('CAN');
+    });
+  });
+
+  describe('Submission', () => {
+    test('calls onSubmit', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      fireEvent.change(screen.getByLabelText('First Name *'), {
+        target: { value: 'John' },
+      });
+
+      fireEvent.click(screen.getByTestId('button-submit'));
+
+      expect(mockProps.onSubmit).toHaveBeenCalled();
+    });
+  });
+
+  describe('Buttons', () => {
+    test('cancel works', () => {
+      render(<IdentityForm {...mockProps} />);
+
+      fireEvent.click(screen.getByTestId('button-cancel'));
       expect(mockProps.onCancel).toHaveBeenCalled();
-      expect(firstNameInput).toHaveValue('');
     });
 
-    test('calls onPrevious when Previous is clicked', () => {
+    test('previous works', () => {
       render(<IdentityForm {...mockProps} />);
 
-      const previousButton = screen.getByTestId('button-previous');
-      fireEvent.click(previousButton);
-
+      fireEvent.click(screen.getByTestId('button-previous'));
       expect(mockProps.onPrevious).toHaveBeenCalled();
-    });
-  });
-
-  describe('Default Props Handling', () => {
-    test('does not fail when onCancel is not provided', () => {
-      const propsWithoutOnCancel = {
-        onSubmit: mockProps.onSubmit,
-        onPrevious: mockProps.onPrevious,
-      };
-
-      render(<IdentityForm {...propsWithoutOnCancel} />);
-
-      const cancelButton = screen.getByTestId('button-cancel');
-      expect(() => fireEvent.click(cancelButton)).not.toThrow();
-    });
-
-    test('does not fail when onPrevious is not provided', () => {
-      const propsWithoutOnPrevious = {
-        onSubmit: mockProps.onSubmit,
-        onCancel: mockProps.onCancel,
-      };
-
-      render(<IdentityForm {...propsWithoutOnPrevious} />);
-
-      const previousButton = screen.getByTestId('button-previous');
-      expect(() => fireEvent.click(previousButton)).not.toThrow();
-    });
-  });
-
-  describe('Loading State', () => {
-    test('displays loading text on submit button when loading', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      expect(screen.getByTestId('button-submit')).toHaveTextContent('Submit');
-    });
-  });
-
-  describe('Form Validation and Accessibility', () => {
-    test('has correct labels for required fields', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      expect(screen.getByLabelText('First Name *')).toBeRequired();
-      expect(screen.getByLabelText('Last Name *')).toBeRequired();
-      expect(screen.getByLabelText('Email *')).toBeRequired();
-      expect(screen.getByLabelText('Address *')).toBeRequired();
-      expect(screen.getByLabelText('City *')).toBeRequired();
-    });
-
-    test('email field has the correct type', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      expect(screen.getByLabelText('Email *')).toHaveAttribute('type', 'email');
-    });
-
-    test('phone field has the correct attributes', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const phoneInput = screen.getByLabelText('(555) 555-5555');
-      expect(phoneInput).toHaveAttribute('type', 'tel');
-      expect(phoneInput).toHaveAttribute('inputMode', 'numeric');
-    });
-  });
-
-  describe('Phone Input Component', () => {
-    test('updates phone and dialing code independently', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const dialingCodeSelect = screen.getByTestId('select-input-dialing-code');
-      const phoneInput = screen.getByLabelText('(555) 555-5555');
-
-      fireEvent.change(dialingCodeSelect, { target: { value: 'CA' } });
-      fireEvent.change(phoneInput, { target: { value: '4161234567' } });
-
-      expect(dialingCodeSelect).toHaveValue('CA');
-      expect(phoneInput).toHaveValue('4161234567');
-    });
-  });
-
-  describe('State Management', () => {
-    test('clears error when field value changes', () => {
-      render(<IdentityForm {...mockProps} />);
-
-      const firstNameInput = screen.getByLabelText('First Name *');
-      fireEvent.change(firstNameInput, { target: { value: 'John' } });
-
-      expect(firstNameInput).toHaveValue('John');
     });
   });
 });

--- a/src/components/form/components/index.jsx
+++ b/src/components/form/components/index.jsx
@@ -11,7 +11,7 @@ const baseSelectStyles = {
 };
 
 const parsedPhoneCountries = countries?.map(country => ({
-  label: `${JSON.parse(`"${country.flag}"`)} ${country.dialingCode}`,
+  label: `${JSON.parse(`"${country.flag}"`)} ${country.name} (${country.dialingCode})`,
   value: country.cca2,
 }));
 
@@ -106,52 +106,53 @@ export const PhoneInput = ({
   onPhoneChange,
 }) => (
   <Form.Group as={Col} xs={12} md={6} controlId="phone" isInvalid={!!phoneError}>
-    <Form.Row>
-      <div className="form-phone">
-        <Col xs={5} md={3} className="px-0 pl-1">
-          <Select
-            label="Dialing code"
-            className="form-input"
-            placeholder="Dialing code *"
-            options={parsedPhoneCountries}
-            value={parsedPhoneCountries?.find((c) => c.value === dialingCodeValue)}
-            onChange={(opt) => onDialingCodeChange(opt?.value || '')}
-            isClearable
-            required
-            isDisabled={dialingCodeDisabled || isLoading}
-            styles={{
-              control: (base) => ({
-                ...base,
-                ...baseSelectStyles,
-                borderRight: 'none',
-                borderTopRightRadius: 0,
-                borderBottomRightRadius: 0,
-                ...((dialingCodeError || phoneError) && { borderColor: 'var(--error-border-color)' }),
-              }),
-            }}
-          />
-        </Col>
-        <Col xs={7} md={9} className="px-0">
-          <Form.Control
-            type="tel"
-            inputMode="numeric"
-            floatingLabel="(555) 555-5555"
-            placeholder="(555) 555-5555"
-            value={phoneValue}
-            disabled={phoneDisabled || isLoading}
-            className={`pr-1 form-phone-input ${phoneDisabled || isLoading ? 'form-input-disabled' : 'form-input'}`}
-            onChange={(e) => onPhoneChange(e.target.value)}
-            required
-          />
-        </Col>
-      </div>
+    <Form.Row className="form-phone">
+
+      <Col xs={12} md={6} className="px-0 pl-1">
+        <Select
+          label="Dialing code"
+          className="mb-3 mb-md-0 form-input select-dialing"
+          classNamePrefix="react-select"
+          placeholder="Dialing code *"
+          options={parsedPhoneCountries}
+          value={parsedPhoneCountries?.find((c) => c.value === dialingCodeValue)}
+          onChange={(opt) => onDialingCodeChange(opt?.value || '')}
+          isClearable
+          required
+          isDisabled={dialingCodeDisabled || isLoading}
+          styles={{
+            control: (base) => ({
+              ...base,
+              ...baseSelectStyles,
+              ...(dialingCodeError || phoneError
+                ? { borderColor: 'var(--error-border-color)' }
+                : {}),
+            }),
+          }}
+        />
+      </Col>
+
+      <Col xs={12} md={6} className="px-0">
+        <Form.Control
+          type="tel"
+          inputMode="numeric"
+          placeholder="(555) 555-5555"
+          value={phoneValue}
+          disabled={phoneDisabled || isLoading}
+          className={`pr-1 form-phone-input ${
+            phoneDisabled || isLoading ? 'form-input-disabled' : 'form-input'
+          }`}
+          onChange={(e) => onPhoneChange(e.target.value)}
+          required
+        />
+      </Col>
+
       {(dialingCodeError || phoneError) && (
         <Form.Control.Feedback type="invalid" className="mt-1">
-          {dialingCodeError}
-          {' '}
-          {phoneError}
+          {dialingCodeError} {phoneError}
         </Form.Control.Feedback>
       )}
+
     </Form.Row>
   </Form.Group>
 );

--- a/src/components/form/index.jsx
+++ b/src/components/form/index.jsx
@@ -33,10 +33,10 @@ const parsedCountries = countries?.map(country => ({
 const countriesWithStates = [UNITED_STATES, CANADA];
 
 const FormHeader = () => (
-  <Form.Row className="flex-column mb-4 pl-1">
-    <h3 className="form-title mb-4">Verify your identity</h3>
+  <Form.Row className="pl-1 mb-4 flex-column">
+    <h3 className="mb-4 form-title">Verify your identity</h3>
     <p className="form-subtitle">
-      <Icon src={WarningFilled} className="align-middle mr-1 text-danger icon-header" />
+      <Icon src={WarningFilled} className="mr-1 align-middle text-danger icon-header" />
       <strong className="pl-4">
         IMPORTANT: You must enter your first/given and last/surname/family name exactly as it appears
         on the identification (ID) you will present at the test center.
@@ -49,31 +49,31 @@ const FormHeader = () => (
 );
 
 const FormActions = ({ onCancel, onPrevious, isLoading }) => (
-  <div className="d-flex justify-content-between border-top px-3 px-md-4 p-md-4 py-4">
-    <div className="d-flex justify-content-start gap-2">
+  <div className="px-3 py-4 d-flex justify-content-between border-top px-md-4 p-md-4">
+    <div className="gap-2 d-flex justify-content-start">
       <Button
         variant="tertiary"
         type="button"
-        className="p-2 px-md-4 mr-1 mr-md-0"
+        className="p-2 mr-1 px-md-4 mr-md-0"
         onClick={onCancel}
         disabled={isLoading}
       >
         Cancel
       </Button>
     </div>
-    <div className="d-flex justify-content-end gap-2">
+    <div className="gap-2 d-flex justify-content-end">
       <Button
         variant="primary"
         text
         type="button"
-        className="mr-2 mr-md-3 p-2 px-md-4"
+        className="p-2 mr-2 mr-md-3 px-md-4"
         onClick={onPrevious}
         disabled={isLoading}
       >
         Previous
       </Button>
       <Button
-        className="p-2 px-md-4 py-3"
+        className="p-2 py-3 px-md-4"
         variant="outline-primary"
         type="submit"
         disabled={isLoading}
@@ -88,14 +88,14 @@ const initialFormState = {
   firstName: { isDisabled: false, value: '', error: null },
   lastName: { isDisabled: false, value: '', error: null },
   email: { isDisabled: false, value: '', error: null },
-  dialingCode: { isDisabled: false, value: null, error: null },
+  dialingCode: { isDisabled: false, value: 'US', error: null },
   phone: { isDisabled: false, value: '', error: null },
   address: { isDisabled: false, value: '', error: null },
   apartment: { isDisabled: false, value: '', error: null },
   city: { isDisabled: false, value: '', error: null },
   state: { isDisabled: false, value: '', error: null },
   postalCode: { isDisabled: false, value: '', error: null },
-  country: { isDisabled: false, value: '', error: null },
+  country: { isDisabled: false, value: 'USA', error: null },
 };
 
 /**
@@ -238,7 +238,7 @@ const IdentityForm = ({
         <div className="p-4">
           <FormHeader />
 
-          <Form.Row className="d-flex flex-wrap">
+          <Form.Row className="flex-wrap d-flex">
             <Input
               id="firstName"
               label="First Name *"
@@ -312,46 +312,6 @@ const IdentityForm = ({
           </Form.Row>
 
           <Form.Row>
-            <Input
-              id="city"
-              label="City *"
-              required
-              value={formData.city.value}
-              error={formData.city.error}
-              isDisabled={formData.city.isDisabled}
-              isLoading={isLoading}
-              onChange={(value) => handleInputChange('city', value)}
-            />
-
-            {showStateAndPostalCodeField && (
-              <SelectInput
-                id="state"
-                label="State / Province"
-                placeholder={countryDivitionPlaceholder[formData.country.value] || 'State / Province *'}
-                options={getStateOptions(formData.country.value)}
-                value={formData.state.value}
-                error={formData.state.error}
-                isDisabled={formData.state.isDisabled}
-                isLoading={isLoading}
-                onChange={(value) => handleInputChange('state', value)}
-              />
-            )}
-          </Form.Row>
-
-          <Form.Row>
-            {showStateAndPostalCodeField && (
-              <Input
-                id="postalCode"
-                label="ZIP / Postal Code *"
-                required
-                value={formData.postalCode.value}
-                error={formData.postalCode.error}
-                isDisabled={formData.postalCode.isDisabled}
-                isLoading={isLoading}
-                onChange={(value) => handleInputChange('postalCode', value)}
-              />
-            )}
-
             <SelectInput
               id="country"
               label="Country / Region"
@@ -363,6 +323,42 @@ const IdentityForm = ({
               isDisabled={formData.country.isDisabled}
               isLoading={isLoading}
               onChange={(value) => handleInputChange('country', value)}
+            />
+
+            <SelectInput
+              id="state"
+              label="State / Province"
+              placeholder={countryDivitionPlaceholder[formData.country.value] || 'State / Province *'}
+              options={getStateOptions(formData.country.value)}
+              value={formData.state.value}
+              error={formData.state.error}
+              isDisabled={formData.state.isDisabled || !showStateAndPostalCodeField}
+              isLoading={isLoading}
+              onChange={(value) => handleInputChange('state', value)}
+            />
+          </Form.Row>
+
+          <Form.Row>
+            <Input
+              id="city"
+              label="City *"
+              required
+              value={formData.city.value}
+              error={formData.city.error}
+              isDisabled={formData.city.isDisabled}
+              isLoading={isLoading}
+              onChange={(value) => handleInputChange('city', value)}
+            />
+
+            <Input
+              id="postalCode"
+              label="ZIP / Postal Code *"
+              required
+              value={formData.postalCode.value}
+              error={formData.postalCode.error}
+              isDisabled={formData.postalCode.isDisabled || !showStateAndPostalCodeField}
+              isLoading={isLoading}
+              onChange={(value) => handleInputChange('postalCode', value)}
             />
           </Form.Row>
         </div>

--- a/src/components/form/index.scss
+++ b/src/components/form/index.scss
@@ -1,4 +1,5 @@
 @import 'react-paragon-topaz/src/variables.scss';
+@import 'assets/variables.scss';
 
 :root {
   // This is defined as a CSS variable instead of a Sass variable because
@@ -12,7 +13,7 @@
 .form-wrapper {
   background-color: #fff;
   border-radius: 8px;
-  border: 1px solid #ced4da;
+  border: 1px solid $border-form-color;
 }
 
 .form-title {
@@ -37,19 +38,45 @@
   }
 }
 
-.form-phone {
-  display: flex;
-  width: 100%;
+@media (min-width: 768px) {
+  .select-dialing .react-select__control {
+    border-right: none;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .form-phone-input {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+}
+
+@media (max-width: 767px) {
+  .select-dialing .react-select__control {
+    border-radius: 0.25rem;
+    border-right: 1px solid $border-form-color;
+  }
+
+  .form-phone-input {
+    border-radius: 0.25rem;
+  }
 }
 
 .form-phone-input input.form-control {
   border-left: none;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+
+  @media screen and (max-width: 767px) {
+    border-left: $border-form-color;
+    border: 1px solid $border-form-color;
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
+  }
 }
 
 .form-input input.form-control {
-  border: 1px solid #ced4da;
+  border: 1px solid $border-form-color;
 }
 
 .form-input input.form-control.is-invalid {
@@ -57,7 +84,7 @@
 }
 
 .form-input input.form-control:hover {
-  outline: 2px solid #ced4da;
+  outline: 2px solid $border-form-color;
 }
 
 .form-input-disabled input.form-control,

--- a/src/features/utils/constants.js
+++ b/src/features/utils/constants.js
@@ -29,7 +29,8 @@ export const countries = countriesData
     cca3,
     cca2,
   }))
-  .filter(({ dialingCode }) => dialingCode);
+  .filter(({ dialingCode }) => dialingCode)
+  .sort((a, b) => a.name.localeCompare(b.name));
 
 /**
  * Returns the exam location formatted as a string.


### PR DESCRIPTION
# Description
In this PR is enhanced the styles for `form` component, now zip code and states input are always visible.

## Screenshot
### Before
<img width="1499" height="680" alt="Screenshot 2026-03-19 at 4 35 38 PM" src="https://github.com/user-attachments/assets/0cf632a9-37a9-4d19-8837-ebc5a6ae79ef" />

### After
<img width="1531" height="699" alt="Screenshot 2026-03-19 at 4 18 14 PM" src="https://github.com/user-attachments/assets/26bba213-2f41-4257-a669-d5618cc20b17" />

## Ticket
https://pearson.atlassian.net/browse/PADV-3169

## How to test
- Go to /exams