### PR TITLE
fix: Reset state and postal code fields when country selection changes

### DIFF
--- a/src/components/form/index.jsx
+++ b/src/components/form/index.jsx
@@ -123,14 +123,29 @@ const IdentityForm = ({
   const [toast, setToast] = useState({ show: false, message: '' });
 
   const handleInputChange = (name, value) => {
-    setFormData(prev => ({
-      ...prev,
-      [name]: {
-        ...prev[name],
-        value,
-        error: null,
-      },
-    }));
+    setFormData(prev => {
+      const updated = {
+        ...prev,
+        [name]: {
+          ...prev[name],
+          value,
+          error: null,
+        },
+      };
+
+      if (name === 'country') {
+        if (!countriesWithStates.includes(value)) {
+          updated.state = {
+            ...prev.state, value: '', error: null, isDisabled: false,
+          };
+          updated.postalCode = {
+            ...prev.postalCode, value: '', error: null, isDisabled: false,
+          };
+        }
+      }
+
+      return updated;
+    });
   };
 
   const formatError = (val) => (Array.isArray(val) ? val.join(' ') : val || null);
@@ -328,6 +343,7 @@ const IdentityForm = ({
             <SelectInput
               id="state"
               label="State / Province"
+              key={`state-${formData.country.value}`}
               placeholder={countryDivitionPlaceholder[formData.country.value] || 'State / Province *'}
               options={getStateOptions(formData.country.value)}
               value={formData.state.value}
@@ -352,6 +368,7 @@ const IdentityForm = ({
 
             <Input
               id="postalCode"
+              key={`state-${formData.country.value}`}
               label="ZIP / Postal Code *"
               required
               value={formData.postalCode.value}


### PR DESCRIPTION
# Description

This PR fixes inconsistent state management and UI desynchronization in the Identity Verification form when switching countries.

Previously, changing the selected country caused `state` and `postalCode` fields to become visually out of sync with the internal form state. In some cases, inputs appeared populated in the UI but their values were not persisted, and in others, stale values remained visible after being programmatically cleared.

# Changes

* Fixed state update logic to consistently use the latest computed state (`updated`).
* Added `key` props to `state` and `postalCode` inputs to force remount when country changes, ensuring UI resets correctly.
* Improved handling of dependent fields by preventing unintended stale values and ensuring proper synchronization between UI and state.

# Result

* UI now accurately reflects the underlying form state at all times.
* Switching between countries no longer causes stale or misleading values.
* Form behavior is predictable and consistent across all country selections.