### PR TITLE
PADV-3210: Fix phone number API error message

### DIFF
--- a/src/components/form/components/index.jsx
+++ b/src/components/form/components/index.jsx
@@ -147,9 +147,15 @@ export const PhoneInput = ({
         />
       </Col>
 
-      {(dialingCodeError || phoneError) && (
+      {dialingCodeError && (
         <Form.Control.Feedback type="invalid" className="mt-1">
-          {dialingCodeError} {phoneError}
+          {dialingCodeError}
+        </Form.Control.Feedback>
+      )}
+
+      {phoneError && (
+        <Form.Control.Feedback type="invalid" className="mt-1">
+          {phoneError.phone_number}
         </Form.Control.Feedback>
       )}
 


### PR DESCRIPTION
### Ticket

https://pearson.atlassian.net/browse/PADV-3210

### Description

This PR fixes how the form component handles the API error messages for phone number validation, on the previous PR of PADV-3210 how the format of the error message sent by the API was modified, this changed broke the form component once the invalid phone number was submited.